### PR TITLE
Use lighter arrow ornaments for menus/details

### DIFF
--- a/assets/css/menus.css
+++ b/assets/css/menus.css
@@ -52,14 +52,14 @@
 }
 
 .menu details > summary:after {
-	content: "▶";
-	font-size: 8px;
+	content: "❭";
+	font-size: 12px;
 	position: absolute;
 }
 
 .menu details[open] > summary:after {
-	content: "▼";
-	font-size: 11px;
+	content: "˅";
+	font-size: 15px;
 }
 
 #sidebar-left .menu details > summary:after {
@@ -242,14 +242,14 @@
 }
 
 #menuToggle details > summary:after {
-	content: "▶";
+	content: "❭";
 	font-size: 16px;
 	position: absolute;
 	left: 230px;
 }
 
 #menuToggle details[open] > summary:after {
-	content: "▼";
+	content: "˅";
 	font-size: 18px;
 	left: 228px;
 }


### PR DESCRIPTION
At the moment, the triangle indicators for the menus look pretty heavy, and disturb the visual impression of the otherwise light layout.
I'd like to suggest to use some more light-weight visual elements like ❭ and ˅.