### PR TITLE
bug: fixes FA5 icon usage at index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@ layout: home
         <div class="col-12 col-12-medium">
           <header class="major">
             <ul class = "actions special">
-              <li><a href="/downloads" class="button icon solid fas fa-download">Download</a></li>
-              <li><a href="/learn" class="button icon solid fas fa-cogs">Use</a></li>
-              <li><a href="/develop" class="button icon solid fas fa-wrench">Extend</a></li>
+              <li><a href="/downloads" class="button solid icon"><span class="fas fa-download"></span> Download</a></li>
+              <li><a href="/learn" class="button icon solid"><span class="fas fa-cogs"></span> Use</a></li>
+              <li><a href="/develop" class="button icon solid"><span class="fas fa-wrench"></span> Extend</a></li>
             </ul>
             <h1>Why ImageJ?</h1>
             <header class="container-whyij">
@@ -73,12 +73,28 @@ layout: home
         <h2>User Resources</h2>
       </header>
       <ul class="actions special">
-        <li><a href="/plugins" class="button icon solid fas fa-plug">Plugins</a></li>
-        <li><a href="/help" class="button icon solid fas fa-hands-helping">Help</a></li>
+        <li>
+          <a href="/plugins" class="button icon solid">
+            <span class="fas fa-plug"></span> Plugins
+          </a>
+        </li>
+        <li>
+          <a href="/help" class="button icon solid">
+            <span class="fas fa-hands-helping"></span> Help
+          </a>
+        </li>
       </ul>
       <ul class="actions special">
-        <li><a href="https://forum.image.sc/tag/imagej" class="button icon solid fas fa-external-link-alt">Forum</a></li>
-        <li><a href="/contribute/citing" class="button icon solid fas fa-quote-left">Cite</a></li>
+        <li>
+          <a href="https://forum.image.sc/tag/imagej" class="button icon solid">
+            <span class="fas fa-external-link-alt"></span> Forum
+          </a>
+        </li>
+        <li>
+          <a href="/contribute/citing" class="button icon solid">
+            <span class="fas fa-quote-left"></span> Cite
+          </a>
+        </li>
       </ul>
     </section>
 
@@ -88,12 +104,28 @@ layout: home
         <h2>Developer Resources</h2>
       </header>
       <ul class="actions special">
-        <li><a href="https://github.com/imagej/" class="button icon solid fas fa-code">Source Code</a></li>
-        <li><a href="https://github.com/imagej/imagej/issues" class="button icon solid fas fa-bullhorn">Report a Bug</a></li>
+        <li>
+          <a href="https://github.com/imagej/" class="button icon solid">
+            <span class="fas fa-code"></span> Source Code
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/imagej/imagej/issues" class="button icon solid">
+            <span class="fas fas fa-bullhorn"></span> Report a Bug
+          </a>
+        </li>
       </ul>
       <ul class="actions special">
-        <li><a href="https://javadoc.scijava.org/SciJava/" class="button icon solid fas fa-terminal">SciJava API</a></li>
-        <li><a href="https://javadoc.scijava.org/ImageJ/" class="button icon solid fas fa-terminal">ImageJ API</a></li>
+        <li>
+          <a href="https://javadoc.scijava.org/SciJava/" class="button icon solid">
+            <span class="fas fa-terminal"></span> SciJava API
+          </a>
+        </li>
+        <li>
+          <a href="https://javadoc.scijava.org/ImageJ/" class="button icon solid">
+            <span class="fas fa-terminal"></span>ImageJ API
+          </a>
+        </li>
       </ul>
 
     </section>


### PR DESCRIPTION
Excited to kick off contributing to the site! This PR resolves a pretty small issue, with lines like:

```html
<li><a href="/downloads" class="button icon solid fas fa-download">Download</a></li>
```

Here, `.fas .fa-download` is being applied to all the text that's a child of the anchor tag. Instead, we should create a new (decorative) element that represents the icon, and then only apply the style there.

```html
<li>
  <a href="/downloads" class="button solid icon">
    <span class="fas fa-download"></span> Download
  </a>
</li>
```

This PR changes all of these cases on the homepage, which resolves ~ 11 buttons of content.

This has two benefits:

1. the font for "Download" should now work as intended, instead of using Font Awesome's text font
2. we now properly use [Font Awesome's decorative icon accessibility features](https://fontawesome.com/v5.15/how-to-use/on-the-web/other-topics/accessibility#svg-decorative), and no longer mark the entire button as `role="img"` with `aria-hidden=true`

Let me know what y'all think!

P.S. there are some installation issues with `webrick` and committing a `Gemfile.lock` - but I can open up another issue or discuss elsewhere!