### PR TITLE
deps: adds `webrick` as an explicit dependency for Ruby >=3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 4.2'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 gem 'html-proofer'
+gem 'webrick'
 
 group :jekyll_plugins do
   gem 'jekyll-sitemap'


### PR DESCRIPTION
In [Ruby 3](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/), `webrick` (or [WEBrick](https://github.com/ruby/webrick)) is no longer packaged in to the default installation, and needs to be explicitly installed as a gem with `bundle`. This PR adds it, so that the build works as-intended for users on Ruby 3. 

Note that this is a no-op on Ruby 2. 

for more context, see: https://github.com/jekyll/jekyll/issues/8523 and https://github.com/github/pages-gem/issues/752

This is a precursor to my CI work for #92!