### PR TITLE
devops: adds jekyll build action for Ruby 2.7, 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Jekyll Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.7.2, 3.0.0]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # caches and runs bundle automatically - see
+    # https://github.com/ruby/setup-ruby#caching-bundle-install-automatically
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec jekyll build


### PR DESCRIPTION
This PR adds a GitHub Action to build the site on Ruby 2.7 and 3. Part of #92.