### PR TITLE
Add a minimal .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+
+[*.md]
+# Markdown can use trailing '  ' to indicate <br />
+trim_trailing_whitespace = false
+


### PR DESCRIPTION
See https://editorconfig.org/.

Mostly to decrease the chance of people nuking Markdown's trailing double-space syntax.

Indent size is left unset.