### PR TITLE
layout: auto-generating "needs vetting" banner for MediaWiki pages

### DIFF
--- a/_includes/warning/mediawiki
+++ b/_includes/warning/mediawiki
@@ -1,0 +1,5 @@
+{% include notice icon="info" content="The content of this page has not been vetted since shifting away from MediaWiki. If you'd like to help, check out the [how to help guide](/events/wiki-grand-opening/how-to-help)!" %}
+
+{%- comment -%}
+# vi:syntax=liquid
+{%- endcomment -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -44,6 +44,9 @@
       <div class="container">
         <div class="box alt"></div>
         <div id="content" class="page-content">
+          {% if page.mediawiki %}
+            {% include warning/mediawiki %}
+          {% endif %}
           {{content}}
         </div>
       </div>


### PR DESCRIPTION
Hey there, this is a PR that resolves the issue brought up in #155 - autogenerating a banner for every page with `mediawiki:` front matter that notes that the page may need vetting, and links to the how-to guide.

The methodology is pretty simple:

* create a new include called `mediawiki`
* in `_layouts/page.html`, put it right at the top of the main content banner 

However, I'm getting an interesting result - this approach "leaks" into the other includes on a notice page. For example consider the [Dichromacy plugin](https://imagej.github.io/plugins/dichromacy).

On live:

<img width="999" alt="Screen Shot 2021-06-11 at 12 43 16 PM" src="https://user-images.githubusercontent.com/14893287/121740895-9bb12780-cab2-11eb-8a37-28ae93f27820.png">

Deploying off of this branch:

<img width="1008" alt="Screen Shot 2021-06-11 at 12 43 30 PM" src="https://user-images.githubusercontent.com/14893287/121740927-a79ce980-cab2-11eb-9b51-dc83f0b6226b.png">

As you can see, the include has "leaked" into the other notice. I did a bit of playing around, and I think there may be an issue with how the `notice` include has been defined; though, I may be missing something. If so, let me know!

Until that's resolved, this can be a draft.

Closes #155.