### PR TITLE
Support interactive documentation and add ImageJ.JS page

### DIFF
--- a/_includes/layout/scripts
+++ b/_includes/layout/scripts
@@ -11,6 +11,10 @@
   src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=default">
 </script>
 {% endif %}
+{% if page.imjoy %}
+<script src="https://lib.imjoy.io/imjoy-loader.js"></script>
+<script src="/assets/js/imjoy-app.js"></script>
+{% endif %}
 <!-- Site code -->
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/dock.js"></script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -63,7 +63,6 @@
 
     <!-- Search results -->
     {% include layout/search-results %}
-
     <!-- Scripts -->
     {% include layout/scripts %}
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -67,18 +67,5 @@
     <!-- Scripts -->
     {% include layout/scripts %}
 
-    <!-- ImJoy App -->
-    {% if page.imjoy %}
-    <div id="menu-container"></div>
-    <script src="https://lib.imjoy.io/imjoy-loader.js"></script>
-    <script src="/assets/js/imjoy-app.js"></script>
-    <style>
-      .imjoy-dialog-control {
-          padding: 0px;
-          line-height: 10px;
-          color: white!important;
-      }
-    </style>
-    {% endif %}
   </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -66,5 +66,19 @@
 
     <!-- Scripts -->
     {% include layout/scripts %}
+
+    <!-- ImJoy App -->
+    {% if page.imjoy %}
+    <div id="menu-container"></div>
+    <script src="https://lib.imjoy.io/imjoy-loader.js"></script>
+    <script src="/assets/js/imjoy-app.js"></script>
+    <style>
+      .imjoy-dialog-control {
+          padding: 0px;
+          line-height: 10px;
+          color: white!important;
+      }
+    </style>
+    {% endif %}
   </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -63,8 +63,8 @@
 
     <!-- Search results -->
     {% include layout/search-results %}
+
     <!-- Scripts -->
     {% include layout/scripts %}
-
   </body>
 </html>

--- a/_pages/software/imagej-js.md
+++ b/_pages/software/imagej-js.md
@@ -1,0 +1,110 @@
+---
+title: ImageJ.JS
+section: Explore:Software
+imjoy: true
+---
+
+ImageJ.JS is web version of ImageJ, we compiled ImageJ (version 1) from Java into Javascript with a Java compiler called [CheerpJ](https://www.leaningtech.com/pages/cheerpj.html). In addition to the modification for making it work better within the browser, importantly, we integrated it with the [ImJoy](https://imjoy.io) plugin ecosystem. The project is currently under active development within the [ImJoy Team](https://github.com/imjoy-team) led by Wei Ouyang.
+
+
+***The latest documentation with full details are avaiable at [ImageJ.JS github repo](https://github.com/imjoy-team/imagej.js), we hightlight a few features below.***
+
+
+# Getting started
+
+You can run ImageJ with all mainstream browsers with one click, no installation and no Java runtime environment needed. It also works on mobile devices.
+
+You can try ImageJ.JS here: [https://ij.imjoy.io](https://ij.imjoy.io) directly, or try our interactive introduction slides by clicking the "Run" button below:
+<!-- ImJoyPlugin: { "type": "web-worker", "hide_code_block": true } -->
+```javascript
+api.createWindow({ src: 'https://slides.imjoy.io/?slides=https://gist.githubusercontent.com/oeway/3968df06b663088eca66f9bd8df94e81/raw/ImageJ.JS-slides-for-OME-Meetings-2021.md', passive: true })
+```
+(There is also a [3-minute introduction video](https://www.youtube.com/embed/QCuKls8NjqY) associated with the interactive slides)
+
+# Sharing images or macro via URL
+To facilitate the sharing of images, macro, and plugins, ImageJ.JS web app supports loading predefined images, macro or plugin by constructing a URL. If you made a ImageJ macro that you want to share, you can store them in your project repo on Github, or simply go to Gist(https://gist.github.com), paste it and get the URL. For example, we stored a demo macro here: [https://gist.github.com/oeway/ab45cc8295efbb0fb5ae1c6f9babd4ac](https://gist.github.com/oeway/ab45cc8295efbb0fb5ae1c6f9babd4ac). Then wen can construct an URL for sharing where user can directly click and run: [https://ij.imjoy.io/?run=https://gist.github.com/oeway/ab45cc8295efbb0fb5ae1c6f9babd4ac](https://ij.imjoy.io/?run=https://gist.github.com/oeway/ab45cc8295efbb0fb5ae1c6f9babd4ac) . This URL can be shared as is, or further shorten by one of the short URL service (e.g. tiny.cc).
+
+
+# ImJoy Integration
+
+ImageJ.JS supports two-way integration with ImJoy, meaning you can either use it as an ImJoy plugin or load other ImJoy plugins into ImageJ.JS. This a a powerful combination, since it brings useful features from ImageJ including file IO, image processing plugins, macro scripting together with web plugins in ImJoy for building easy to use modern UI and powerful deep learning libraries.
+
+In the standalone mode (simply go to https://ij.imjoy.io), you will have acess to ImJoy features via the ImJoy icon located in the top-left corner of ImageJ. You can load ImJoy plugins into the workspace via a plugin URL, especially for those plugin that calls ImageJ.JS.
+
+For example, the following code shows how to call ImageJ.JS api from an ImJoy plugin:
+<!-- ImJoyPlugin: { "type": "web-worker", "editor_height": "400px"} -->
+```javascript
+async function run(){
+    const ij = await api.createWindow({src: "https://ij.imjoy.io"})
+    await ij.runMacro(`print("hello world");`)
+}
+
+run()
+```
+
+The most common use case is to use it with Python, e.g. in a Jupyter notebook or in ImJoy.
+
+Try an online demo: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imjoy-team/imagej.js/master?filepath=examples%2Fgetting-started.ipynb)
+
+# Interactive documentation
+
+ImageJ.JS is a browser application that can be easily embedded into an website including project site and documentation. 
+
+In fact, we have added the support for running ImageJ in the ImageJ wiki, so you can directly run ImageJ macro and other ImJoy plugins directly.
+
+For example, you can click and try the `Run` button bellow to see a basic imagej macro for image segmentation (Thanks to Romain Guiet who provided this minimal example):
+<!-- ImJoyPlugin: { "type": "macro" } -->
+```javascript
+run("Blobs (25K)");
+setAutoThreshold("Default");
+setOption("BlackBackground", true);
+run("Convert to Mask");
+run("Analyze Particles...", "size=5-Infinity add");
+```
+
+# Run ImageJ.JS and ImJoy in ImageJ wiki
+You can easily turn a markdown code block into executable and editable code block by: 
+ 1. Set `imjoy: true` to the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
+ 2. Add a comment `<!-- ImJoyPlugin: { ... } -->` before your code block. Inside the `{}` you can pass settings for setting up the ImJoy plugin.
+ 
+For example the above code block is rendered from:
+````markdown
+<!-- ImJoyPlugin: { "type": "macro"} -->
+```javascript
+print("hello");
+```
+````
+
+To make it editable immediately, you can set `startup_mode` to `"edit"`:
+````markdown
+<!-- ImJoyPlugin: { "type": "macro", "startup_mode": "edit", "editor_height": "100px"} -->
+```javascript
+print("hello");
+```
+````
+
+For more detailed usage, please refer to [ImJoy Docs](https://imjoy-team.github.io/imjoy-docs/#/).
+
+# Run ImageJ.JS in interactive slides
+
+Similarily to the ImageJ wiki integration, you can also create interactive slides which has ImageJ.JS directly embeded in. 
+This features is useful for teaching purposes, it enables seamless interactive live demo during the presentation and the students can also go back to the same slides and interact with the demos.
+
+You can click [this link](https://slides.imjoy.io/?slides=https://raw.githubusercontent.com/imjoy-team/imjoy-slides/master/slides/run-imagej.js-side-by-side.md) or the "Run" button below:
+
+<!-- ImJoyPlugin: { "type": "web-worker", "hide_code_block": true } -->
+```javascript
+api.createWindow({ src: 'https://slides.imjoy.io/?slides=https://raw.githubusercontent.com/imjoy-team/imjoy-slides/master/slides/run-imagej.js-side-by-side.md', passive: true })
+```
+
+For more detailed usage, please refer to [ImJoy Slides](https://github.com/imjoy-team/imjoy-slides).
+
+# Citation
+
+ImageJ.JS is a part of the ImJoy project, please consider citing the ImJoy paper on Nature Methods ([https://www.nature.com/articles/s41592-019-0627-0](https://www.nature.com/articles/s41592-019-0627-0), [free access](https://rdcu.be/bYbGO) ):
+
+```
+Ouyang, W., Mueller, F., Hjelmare, M. et al. ImJoy: an open-source computational platform for the deep learning era. Nat Methods (2019) doi:10.1038/s41592-019-0627-0
+```
+
+Alternatively, you can also cite: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4944984.svg)](https://doi.org/10.5281/zenodo.4944984).

--- a/_pages/software/imagej-js.md
+++ b/_pages/software/imagej-js.md
@@ -27,7 +27,7 @@ To facilitate the sharing of images, macro, and plugins, ImageJ.JS web app suppo
 
 # ImJoy Integration
 
-ImageJ.JS supports two-way integration with ImJoy, meaning you can either use it as an ImJoy plugin or load other ImJoy plugins into ImageJ.JS. This a a powerful combination, since it brings useful features from ImageJ including file IO, image processing plugins, macro scripting together with web plugins in ImJoy for building easy to use modern UI and powerful deep learning libraries.
+ImageJ.JS supports two-way integration with [ImJoy](/software/imjoy), meaning you can either use it as an ImJoy plugin or load other ImJoy plugins into ImageJ.JS. This a a powerful combination, since it brings useful features from ImageJ including file IO, image processing plugins, macro scripting together with web plugins in ImJoy for building easy to use modern UI and powerful deep learning libraries.
 
 In the standalone mode (simply go to https://ij.imjoy.io), you will have acess to ImJoy features via the ImJoy icon located in the top-left corner of ImageJ. You can load ImJoy plugins into the workspace via a plugin URL, especially for those plugin that calls ImageJ.JS.
 

--- a/_pages/software/imjoy.md
+++ b/_pages/software/imjoy.md
@@ -15,13 +15,13 @@ The ImJoy project was started at Institut Pasteur in 2018. It is currently activ
 ImJoy is a progressive web application which you can run directly in your browser without installation. Go to [https://imjoy.io](https://imjoy.io) and click "Start ImJoy".
 
 ImJoy can also be embedded directly into documentations, for example, if you click "Run", you will see the same ImJoy interface:
-<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": false } -->
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": true } -->
 ```js
 api.createWindow({src: 'https://imjoy.io/#/app', passive: true})
 ```
 
 Since ImJoy itself doesn't provide any functional plugins, for any actual application, you will need to work with the corresponding plugins. For example, if you click "Run" below, you will see a demo plugin which does image classification with lightweight deep learning model running in the browser:
-<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": false } -->
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": true } -->
 ```js
 api.createWindow({src: 'https://github.com/imjoy-team/imjoy-plugins/blob/master/repository/HPA-Classification.imjoy.html'})
 ```
@@ -110,8 +110,8 @@ api.alert("Hello from ImJoy!")
 You can also embed a plugin window into the page:
 <!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px"} -->
 ```js
-api.createWindow({src: "https://hms-dbmi.github.io/vizarr", name: "visualizating HCS zarr images with vizarr"}).then((viewer)=>{
-    viewer.add_image({source: "https://minio-dev.openmicroscopy.org/idr/idr0001-graml-sysgro/JL_120731_S6A/pr_45/2551.zarr", name: "Demo Image"})
+api.createWindow({src: "https://hms-dbmi.github.io/vizarr", name: "Vizarr Demo"}).then((viewer)=>{
+    viewer.add_image({source: "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr", name: "Demo Image"})
 })
 ```
 
@@ -153,6 +153,10 @@ api.getPlugin({src: 'https://github.com/imjoy-team/imjoy-plugins/blob/master/rep
 ```
 
 For more detailed usage, please refer to [ImJoy Docs](https://imjoy-team.github.io/imjoy-docs/#/).
+
+## Running ImageJ.JS in ImageJ wiki
+[ImageJ.JS](https://ij.imjoy.io) is a web version of ImageJ, and it can be used as an ImJoy plugin and embeded directly in the ImageJ wiki. For more details, please refer to the [ImageJ.JS page](/software/imagej-js).
+
 
 # Documentation
 

--- a/_pages/software/imjoy.md
+++ b/_pages/software/imjoy.md
@@ -1,0 +1,172 @@
+---
+title: ImJoy
+section: Explore:Software
+doi: 10.1038/s41592-019-0627-0
+imjoy: true
+---
+
+# ImJoy: Supercharging interactivity and scalability of data science!
+
+ImJoy is a plugin powered hybrid computing platform for deploying deep learning applications such as advanced image analysis tools.
+
+The ImJoy project was started at Institut Pasteur in 2018. It is currently actively improved and maintained by the ImJoy Team led by Wei Ouyang (SciLifeLab & KTH in Stockholm). The team consists of members from different institutions who meet weekly and continuously improving the software and expanding the plugin ecosystem.
+
+# Getting started
+ImJoy is a progressive web application which you can run directly in your browser without installation. Go to [https://imjoy.io](https://imjoy.io) and click "Start ImJoy".
+
+ImJoy can also be embedded directly into documentations, for example, if you click "Run", you will see the same ImJoy interface:
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": false } -->
+```js
+api.createWindow({src: 'https://imjoy.io/#/app', passive: true})
+```
+
+Since ImJoy itself doesn't provide any functional plugins, for any actual application, you will need to work with the corresponding plugins. For example, if you click "Run" below, you will see a demo plugin which does image classification with lightweight deep learning model running in the browser:
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": false } -->
+```js
+api.createWindow({src: 'https://github.com/imjoy-team/imjoy-plugins/blob/master/repository/HPA-Classification.imjoy.html'})
+```
+
+For more plugin examples, please check out the [gallery](https://imjoy.io/docs/#/gallery).
+
+# ImJoy Plugin development
+
+ImJoy plugins can be provide as a single text file ( `*.imjoy.html`) or a web URL hosted somehwere else. The most common way to build ImJoy is to provide a plugin file.
+
+Here is an basic plugin file for ImJoy:
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "400px", "hide_code_block": false } -->
+```html
+<config lang="json">
+{
+  "name": "Pokémon Chooser",
+  "type": "web-worker",
+  "tags": [],
+  "ui": "",
+  "version": "0.1.0",
+  "cover": "",
+  "description": "This is a demo plugin for choosing Pokémons",
+  "icon": "extension",
+  "inputs": null,
+  "outputs": null,
+  "api_version": "0.1.8",
+  "env": "",
+  "permissions": [],
+  "requirements": [],
+  "dependencies": []
+}
+</config>
+<script lang="javascript">
+class ImJoyPlugin{
+    async setup(){
+        await api.log("plugin initialized")
+    }
+    async choosePokemon(){
+        const pokemon = await api.prompt("What is your favorite Pokémon?", "Pikachu")
+        await api.showMessage("Your have chose " + pokemon + " as your Pokémon.")
+    }
+    async run(ctx){
+        await this.choosePokemon()
+    }
+}
+api.export(new ImJoyPlugin())
+</script>
+```
+
+If you are interested in learning how to develop ImJoy plugins, We recommend the tutorial we made for the I2K conference: [https://imjoy.io/docs/#/i2k_tutorial](https://imjoy.io/docs/#/i2k_tutorial). It is an interactive documentation where you can follow step by step.
+
+
+# Open integrations
+As part of our mission, we try to bring existing aand future software tools together by connecting them with the [ImJoy RPC protocol](https://github.com/imjoy-team/imjoy-rpc). This is not only internally for connecting plugins in the same workflow, but it also provide a way to integrate other software tools into the same workflow, or bring the ImJoy plugin system to website, online data repository, web applications and other software tools.
+
+We support two-way integration: 1) connect existing web app or software tools as an ImJoy plugin 2) integrate ImJoy core to other website or software tools. For more implementation details, please refer to the [integration docs](https://github.com/imjoy-team/imjoy-core/blob/master/docs/integration.md).
+
+Here is a list of integration examples:
+ * [ImageJ.JS](https://ij.imjoy.io)
+ * [Jupyter Notebooks Extension](https://github.com/imjoy-team/imjoy-jupyter-extension)
+ * [BioImage Model Zoo](https://bioimage.io)
+ * [OpenFlexure](https://openflexure.org/)
+ * [OMERO](https://github.com/will-moore/omero-imjoy)
+ * [ImJoy Slides](https://slides.imjoy.io)
+ * [ImJoy Docs](https://imjoy-team.github.io/imjoy-docs/)
+
+# Running ImJoy plugins in the ImageJ wiki
+As another example of open integration, ImJoy can be enabled in the ImageJ wiki. In any markdown page, you can easily turn a markdown code block into executable and editable code block by: 
+ 1. Set `imjoy: true` to the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
+ 2. Add a comment `<!-- ImJoyPlugin: { ... } -->` before your code block. Inside the `{}` you can pass settings for setting up the ImJoy plugin.
+
+For example, the following code block with Run button is rendered with the above setting:
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px"} -->
+```js
+api.alert("Hello from ImJoy!")
+```
+
+Here is the corresponding markdown code:
+````markdown
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px"} -->
+```js
+api.alert("Hello from ImJoy!")
+```
+````
+
+You can also embed a plugin window into the page:
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px"} -->
+```js
+api.createWindow({src: "https://hms-dbmi.github.io/vizarr", name: "visualizating HCS zarr images with vizarr"}).then((viewer)=>{
+    viewer.add_image({source: "https://minio-dev.openmicroscopy.org/idr/idr0001-graml-sysgro/JL_120731_S6A/pr_45/2551.zarr", name: "Demo Image"})
+})
+```
+
+Or show a popup dialog:
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": true} -->
+```js
+api.showDialog({src: "https://hms-dbmi.github.io/vizarr", name: "visualizating HCS zarr images with vizarr"}).then((viewer)=>{
+    viewer.add_image({source: "https://minio-dev.openmicroscopy.org/idr/idr0001-graml-sysgro/JL_120731_S6A/pr_45/2551.zarr", name: "Demo Image"})
+})
+```
+
+You can also run other plugin types, including Python plugins which will be executed via mybinder.org. 
+
+<!-- ImJoyPlugin: { "type": "native-python","editor_height": "200px", "hide_code_block": false} -->
+```python
+from imjoy import api
+
+class ImJoyPlugin():
+    async def setup(self):
+        pass
+
+    async def choosePokemon(self):
+        pokemon = await api.prompt("What is your favorite Pokémon?", "Pikachu")
+        await api.showMessage("Your have chose " + pokemon + " as your Pokémon.")
+
+    async def run(self, ctx):
+        await self.choosePokemon()
+
+api.export(ImJoyPlugin())
+```
+
+As a more useful demoo, the following code load an [pixel classifier plugin](https://github.com/imjoy-team/imjoy-plugins/blob/master/repository/PixelClassifier.imjoy.html) for interactive image segmentation with scikit-image and scikit-learn. 
+(Please note that it can take a few minutes to run for the first time.)
+<!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px", "hide_code_block": true} -->
+```js
+api.getPlugin({src: 'https://github.com/imjoy-team/imjoy-plugins/blob/master/repository/PixelClassifier.imjoy.html'}).then((plugin)=>{
+    plugin.run()
+})
+```
+
+For more detailed usage, please refer to [ImJoy Docs](https://imjoy-team.github.io/imjoy-docs/#/).
+
+# Documentation
+
+Full documentation can be found at [https://imjoy.io/docs/](https://imjoy.io/docs/)
+
+
+## Publication
+
+* Ouyang, W., Mueller, F., Hjelmare, M. et al. ImJoy: an open-source computational platform for the deep learning era. Nature Methods (2019), https://doi.org/10.1038/s41592-019-0627-0, [free access](https://rdcu.be/bYbGO)
+
+## Code of Conduct
+
+Help us keep the ImJoy community open and inclusive. Please read and follow our [Code of Conduct](https://github.com/imjoy-team/ImJoy/blob/master/docs/CODE_OF_CONDUCT.md).
+
+## License
+
+[MIT License](https://github.com/imjoy-team/ImJoy/blob/master/LICENSE)

--- a/assets/js/imjoy-app.js
+++ b/assets/js/imjoy-app.js
@@ -1,0 +1,682 @@
+(function () {
+    "use strict";
+    function randId() {
+        // Math.random should be unique because of its seeding algorithm.
+        // Convert it to base 36 (numbers + letters), and grab the first 9 characters
+        // after the decimal.
+        return Math.random().toString(36).substr(2, 9);
+    };
+
+    function _typeof(obj) {
+        if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+            _typeof = function (obj) {
+                return typeof obj;
+            };
+        } else {
+            _typeof = function (obj) {
+                return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+            };
+        }
+        return _typeof(obj);
+    }
+
+    function styleInject(css, ref) {
+        if (ref === void 0) ref = {};
+        var insertAt = ref.insertAt;
+        if (!css || typeof document === "undefined") {
+            return;
+        }
+        var head = document.head || document.getElementsByTagName("head")[0];
+        var style = document.createElement("style");
+        style.type = "text/css";
+        if (insertAt === "top") {
+            if (head.firstChild) {
+                head.insertBefore(style, head.firstChild);
+            } else {
+                head.appendChild(style);
+            }
+        } else {
+            head.appendChild(style);
+        }
+        if (style.styleSheet) {
+            style.styleSheet.cssText = css;
+        } else {
+            style.appendChild(document.createTextNode(css));
+        }
+    }
+    var css = `.imjoy-window{border-style: solid;border-width: 1px;color: #b3b3b3; width: 100%; height:600px;max-width:100%; max-height:200vh;}
+.docsify-run-button,.docsify-run-button span,.fullscreen-button,.fullscreen-button span, .docsify-edit-button,.docsify-edit-button span{cursor:pointer;transition:all .25s ease}
+.docsify-run-button,.docsify-edit-button,.fullscreen-button{z-index:1;height: 35px;margin-right: 6px;line-height: 10px;overflow:visible;padding:.65em .8em;border:0;border-radius:0;outline:0;font-size:1em;background:#448aff;color:#fff!important;opacity:0.7}
+.docsify-run-button span, .fullscreen-button span, .docsify-edit-button span{border-radius:3px;background:inherit;pointer-events:none}
+.docsify-run-button:focus,pre:hover .docsify-run-button, .fullscreen-button:focus,pre:hover .fullscreen-button, .docsify-edit-button:focus,pre:hover .docsify-edit-button{opacity:1}
+.docsify-close-button{position: absolute;right: 4px;top: 4px;line-height: 10px;height: 40px;z-index:3;cursor:pointer;padding:.65em .8em;border:0;border-radius:0;outline:0;font-size:1em;background:#448aff;color:#fff!important;}
+.docsify-fullscreen-button{position: absolute;right: 42px;top: 4px;line-height: 10px;height: 40px;z-index:3;cursor:pointer;padding:.65em .8em;border:0;border-radius:0;outline:0;font-size:1em;background:#448aff;color:#fff!important;}
+.docsify-loader {position: absolute;left: 13px;margin-top: 5px;display: inline-block;transform: translate(-50%, -50%);transform: -webkit-translate(-50%, -50%);transform: -moz-translate(-50%, -50%);transform: -ms-translate(-50%, -50%);border: 6px solid #f3f3f3; /* Light grey */border-top: 6px solid #448aff; /* Blue */border-radius: 50%;width: 30px;height: 30px;animation: spin 2s linear infinite;}
+@keyframes spin {0% { transform: rotate(0deg); }100% { transform: rotate(360deg); }}
+.docsify-status {position: absolute;left: 130px;display: inline-block;font-size:13px;}
+.docsify-progressbar-container{display: inline-block;position: absolute; width: 100%;left: 0; height:3px;color:#000!important;background-color:#f1f1f1!important}
+.docsify-status .tooltiptext {visibility: hidden; width: 120px;background-color: black;color: #fff;text-align: center;border-radius: 6px;padding: 5px 0;position: absolute;z-index: 1;}
+.docsify-status:hover .tooltiptext {visibility: visible!important;}
+.show-code-button{text-align: center; color: var(--docsifytabs-tab-highlight-color); cursor: pointer;}
+`;
+    styleInject(css);
+
+    const i18n = {
+        runButtonText: "Run",
+        editButtonText: "Edit",
+        errorText: "Error",
+        successText: "Done"
+    };
+
+    async function runCode(mode, config, code) {
+        // make a copy of it
+
+        if (config.lang === 'js') config.lang = 'javascript';
+        if (config.lang === 'py') config.lang = 'python';
+        if (config.lang === 'ijm') config.lang = 'javascript';
+
+        const makePluginSource = (src, config) => {
+            if (config.type && !config._parsed) {
+                if(config.type === 'macro'){
+                    config.passive = false;
+                    src = `
+                    async function setup(){
+                        const source = \`${src}\`;
+                        let ij = await api.getWindow("ImageJ.JS-${config.namespace}")
+                        if(!ij){
+                            ij = await api.createWindow({src:"https://ij.imjoy.io", name:"ImageJ.JS-${config.namespace}"})
+                        }
+                        await ij.runMacro(source)
+                    }
+                    api.export({setup});                    
+                    `
+                    config.type = 'web-worker';
+                }
+                const cfg = Object.assign({}, config)
+                cfg.api_version = cfg.api_version || "0.1.8";
+                cfg.name = cfg.name || (config.id && "Plugin-" + config.id) || "Plugin-" + randId();
+                cfg.description = cfg.description || "[TODO: describe this plugin with one sentence.]"
+                cfg.tags = cfg.tags || []
+                cfg.version = cfg.version || "0.1.0"
+                cfg.ui = cfg.ui || ""
+                cfg.cover = cfg.cover || ""
+                cfg.icon = cfg.icon || "extension"
+                cfg.inputs = cfg.inputs || null
+                cfg.outputs = cfg.outputs || null
+                cfg.env = cfg.env || ""
+                cfg.permissions = cfg.permissions || []
+                cfg.requirements = cfg.requirements || []
+                cfg.dependencies = cfg.dependencies || []
+                if (config.type === 'window') {
+                    cfg.defaults = {}
+                }
+
+                if (config.lang !== 'html')
+                    src = `<config lang="json">\n${JSON.stringify(cfg, null, 1)}\n</config>\n<script lang="${config.lang}">\n${src}<\/script>`;
+                else
+                    src = `<config lang="json">\n${JSON.stringify(cfg, null, 1)}\n</config>\n${src}`;
+            }
+            return src
+        }
+
+        const runPluginSource = async (code, initPlugin, windowId, config) => {
+            config = Object.assign({}, config);
+            // automatically set passive mode if there is no export statement
+            if (config.passive === undefined) {
+                if (code && !code.includes("api.export(")) {
+                    config.passive = true;
+                }
+            }
+            const isHTML = code.trim().startsWith('<')
+            if (isHTML || (config.lang === 'html' && !config.type)) {
+                const source_config = await window.imjoy.pm.parsePluginCode(code)
+                delete source_config.namespace
+                for (const k of Object.keys(source_config)) {
+                    config[k] = source_config[k]
+                }
+                config.passive = source_config.passive || config.passive;
+                config._parsed = true;
+            } else {
+                config._parsed = false;
+            }
+            const src = makePluginSource(code, config);
+            const progressElem = document.getElementById('progress_' + config.namespace)
+            if (progressElem) progressElem.style.width = `0%`;
+            // disable hot reloading for passive plugin
+            if (config.passive) {
+                config.hot_reloading = false
+            }
+     
+            try {
+                if (config.type === 'window') {
+                    const wElem = document.getElementById(windowId)
+                    if (wElem) wElem.classList.add("imjoy-window");
+                    await window.imjoy.pm.imjoy_api.createWindow(initPlugin, {
+                        src,
+                        namespace: config.namespace,
+                        tag: config.tag,
+                        window_id: windowId,
+                        w: config.w,
+                        h: config.h,
+                        hot_reloading: config.hot_reloading
+                    })
+                } else {
+                    const plugin = await window.imjoy.pm.imjoy_api.getPlugin(null, {
+                        src,
+                        namespace: config.namespace,
+                        tag: config.tag,
+                        hot_reloading: config.hot_reloading
+                    })
+                    try {
+                        if (plugin.run) {
+                            await plugin.run({
+                                config: {},
+                                data: {}
+                            });
+                        }
+                    } catch (e) {
+                        this.showMessage(e.toString())
+                    }
+
+                }
+            } finally {
+                if (progressElem) progressElem.style.width = `100%`;
+
+            }
+        }
+        if (mode === 'edit') {
+            const wElem = document.getElementById(config.window_id)
+            if (wElem) wElem.classList.add("imjoy-window");
+            const cfg = Object.assign({}, config)
+            delete cfg.passive
+            delete cfg.editor_height
+            let editorWindow;
+            let pluginInEditor;
+            let stopped;
+            const api = window.imjoy.pm.imjoy_api;
+            cfg.ui_elements = {
+                save: {
+                    _rintf: true,
+                    type: 'button',
+                    label: "Save",
+                    visible: false,
+                    icon: "content-save",
+                    callback(content) {
+                        console.log(content)
+                    }
+                },
+                run: {
+                    _rintf: true,
+                    type: 'button',
+                    label: "Run",
+                    icon: "play",
+                    visible: true,
+                    shortcut: 'Shift-Enter',
+                    async callback(content) {
+                        try {
+                            editorWindow.setLoader(true);
+                            editorWindow.updateUIElement('stop', {
+                                visible: true
+                            })
+                            api.showProgress(editorWindow, 0);
+                            // make an exception for imagej macro and try to reuse existing app
+                            if(config.type !== 'macro'){
+                                const outputContainer = document.getElementById('output_' + config.namespace)
+                                outputContainer.innerHTML = "";
+                            }
+       
+                            config.hot_reloading = true;
+                            pluginInEditor = await runPluginSource(content, editorWindow, null, config)
+                            if (stopped) {
+                                pluginInEditor = null;
+                                return;
+                            }
+                            if (pluginInEditor && pluginInEditor.run) {
+                                return await pluginInEditor.run({
+                                    config: {},
+                                    data: {}
+                                });
+                            }
+                            if (stopped) {
+                                pluginInEditor = null;
+                                return;
+                            }
+                        } catch (e) {
+                            api.showMessage(editorWindow, "Failed to load plugin, error: " + e.toString());
+                        } finally {
+                            editorWindow.updateUIElement('stop', {
+                                visible: false
+                            })
+                            editorWindow.setLoader(false);
+                            api.showProgress(editorWindow, 100);
+                        }
+                    }
+                },
+                stop: {
+                    _rintf: true,
+                    type: 'button',
+                    label: "Stop",
+                    style: "color: #ff0080cf;",
+                    icon: "stop",
+                    visible: false,
+                    async callback() {
+                        stopped = true;
+                        await editorWindow.setLoader(false);
+                        await editorWindow.updateUIElement('stop', {
+                            visible: false
+                        })
+                    }
+                },
+                export: {
+                    _rintf: true,
+                    type: 'button',
+                    label: "Export",
+                    icon: "file-download-outline",
+                    visible: true,
+                    async callback(content) {
+                        const fileName = (pluginInEditor && pluginInEditor.config.name && pluginInEditor.config.name + '.imjoy.html') || config.name + '.imjoy.html' || "myPlugin.imjoy.html";
+                        await api.exportFile(editorWindow, makePluginSource(content, config), fileName);
+                    }
+                }
+            }
+            editorWindow = await imjoy.pm.imjoy_api.createWindow(null, {
+                src: 'https://if.imjoy.io/',
+                config: cfg,
+                data: {
+                    code,
+                },
+                window_id: cfg.window_id,
+                namespace: cfg.namespace
+            })
+
+            if (config.editor_height) document.getElementById(editorWindow.config.window_id).style.height = config.editor_height;
+        } else if (mode === 'run') {
+            await runPluginSource(code, null, config.window_id, config)
+        } else {
+            throw "Unsupported mode: " + mode
+        }
+    }
+
+    function execute(preElm, mode) {
+        mode = mode || 'run';
+        var codeElm = preElm.querySelector("code");
+        const code = codeElm.textContent || codeElm.innerText;
+        const showCodeBtn = preElm.querySelector('.show-code-button');
+
+        showCodeBtn.style.display = 'none';
+
+        try {
+
+            const id = randId();
+            preElm.pluginConfig = preElm.pluginConfig || {};
+            preElm.pluginConfig.id = id;
+
+            preElm.pluginConfig.namespace = id;
+            preElm.pluginConfig.lang = preElm.getAttribute('data-lang');
+
+            const outputFullscreenElm = preElm.querySelector(".fullscreen-button");
+            outputFullscreenElm.onclick = () => {
+                const outputElem = document.getElementById('output_' + id);
+                if (outputElem.requestFullscreen) {
+                    outputElem.requestFullscreen();
+                } else if (outputElem.webkitRequestFullscreen) {
+                    /* Safari */
+                    outputElem.webkitRequestFullscreen();
+                } else if (outputElem.msRequestFullscreen) {
+                    /* IE11 */
+                    outputElem.msRequestFullscreen();
+                }
+            }
+            let hideCodeBlock = preElm.pluginConfig.hide_code_block;
+            if (mode === 'edit') {
+                // remove the github corner in edit mode
+                const githubCorner = document.querySelector('.github-corner')
+                if (githubCorner) githubCorner.parentNode.removeChild(githubCorner);
+            }
+            const customElements = preElm.querySelectorAll(":scope > div[id]")
+            for (const elm of customElements) {
+                preElm.removeChild(elm);
+            }
+
+            if (mode === 'edit') {
+                const customElements = preElm.querySelectorAll(":scope > button")
+                for (const elm of customElements) {
+                    elm.style.display = "none";
+                }
+                preElm.pluginConfig.window_id = 'code_' + id;
+                preElm.insertAdjacentHTML('afterBegin', `<div id="${'code_' + id}"></div><div id="${'output_' + id}"></div>`)
+                preElm.insertAdjacentHTML('afterBegin', `<button class="docsify-close-button" id="${'close_' + id}">x</button>`);
+                preElm.insertAdjacentHTML('afterBegin', `<button class="docsify-fullscreen-button" id="${'fullscreen_' + id}">+</button>`);
+                preElm.insertAdjacentHTML('afterBegin', `<div id="${'progress_container_' + id}" style="top: 1px;" class="docsify-progressbar-container"><div class="docsify-progressbar" style="background-color:#2196F3!important;height:3px;" id="${'progress_' + id}"> </div></div>`)
+                preElm.insertAdjacentHTML('beforeEnd', `<div class="docsify-status" style="font-size:13px;left: 4px;" id="${'status_' + id}"></div>`);
+                const closeElem = document.getElementById('close_' + id)
+                const fullscreenElm = document.getElementById('fullscreen_' + id);
+                const statusElem = document.getElementById('status_' + id);
+                const editorElem = document.getElementById('code_' + id);
+                const outputElem = document.getElementById('output_' + id);
+                const editorHeight = parseInt(preElm.pluginConfig.editor_height || "600px")
+                statusElem.style.top = `${editorHeight - 20}px`;
+                editorElem.style.height = `${editorHeight}px`
+                editorElem.style.paddingBottom = '10px';
+                closeElem.onclick = function () {
+                    editorElem.parentNode.removeChild(editorElem)
+
+                    outputElem.parentNode.removeChild(outputElem)
+                    if (hideCodeBlock) {
+                        showCodeBtn.style.display = "block";
+                        codeElm.style.display = "none";
+                    } else {
+                        showCodeBtn.style.display = "none";
+                        codeElm.style.display = "block";
+                    }
+
+                    for (const elm of customElements) {
+                        elm.style.display = "inline-block";
+                    }
+                    this.parentNode.removeChild(this)
+                    fullscreenElm.parentNode.removeChild(fullscreenElm);
+                }
+                fullscreenElm.onclick = function () {
+                    if (preElm.requestFullscreen) {
+                        preElm.requestFullscreen();
+                    } else if (preElm.webkitRequestFullscreen) {
+                        /* Safari */
+                        preElm.webkitRequestFullscreen();
+                    } else if (preElm.msRequestFullscreen) {
+                        /* IE11 */
+                        preElm.msRequestFullscreen();
+                    }
+                }
+
+                preElm.style.overflow = "hidden";
+                outputElem.style.overflow = "auto";
+
+            } else {
+                // run mode
+                preElm.pluginConfig.window_id = 'output_' + id;
+                preElm.insertAdjacentHTML('beforeEnd', `<div id="${'progress_container_' + id}" class="docsify-progressbar-container"><div class="docsify-progressbar" style="background-color:#2196F3!important;height:3px;" id="${'progress_' + id}"> </div></div>`)
+                preElm.insertAdjacentHTML('beforeEnd', `<div class="docsify-status" style="margin-top: 8px;" id="${'status_' + id}"/>`);
+                preElm.insertAdjacentHTML('beforeEnd', `<div id="${'code_' + id}"></div><div id="${'output_' + id}"></div>`)
+                codeElm.style.display = "block";
+                showCodeBtn.style.display = 'none';
+                const outputElem = document.getElementById('output_' + id);
+                outputElem.style.overflow = 'auto';
+            }
+            const loader = preElm.querySelector(".docsify-loader")
+            loader.style.display = "inline-block";
+            const runBtn = preElm.querySelector(".docsify-run-button")
+            if (runBtn) runBtn.innerHTML = "&nbsp; &nbsp; &nbsp; ";
+            if (window.imjoy) {
+                runCode(mode, preElm.pluginConfig, code).finally(() => {
+                    loader.style.display = "none";
+                    const runBtn = preElm.querySelector(".docsify-run-button")
+                    if (runBtn) runBtn.innerHTML = i18n.runButtonText;
+                    const outputElem = document.getElementById('output_' + id);
+                    if (outputElem && outputElem.children.length > 0)
+                        outputFullscreenElm.style.display = "inline-block";
+
+                })
+            } else {
+                window.document.addEventListener("imjoy_app_started", () => {
+                    runCode(mode, preElm.pluginConfig, code).finally(() => {
+                        loader.style.display = "none";
+                        const runBtn = preElm.querySelector(".docsify-run-button")
+                        if (runBtn) runBtn.innerHTML = i18n.runButtonText;
+                    })
+                })
+            }
+
+            if (hideCodeBlock || mode === 'edit') {
+                codeElm.style.display = "none";
+                if (mode !== 'edit') {
+                    showCodeBtn.style.display = "block";
+
+                }
+            }
+            document.addEventListener("fullscreenchange", function (e) {
+
+                const fullScreenMode = document.fullScreen || document.mozFullScreen || document.webkitIsFullScreen;
+                if (e.target === preElm) {
+                    const closeElem = document.getElementById('close_' + id)
+                    const fullscreenElm = document.getElementById('fullscreen_' + id);
+                    const editorElem = document.getElementById('code_' + id);
+                    const outputElem = document.getElementById('output_' + id);
+                    const statusElem = document.getElementById('status_' + id);
+                    if (fullScreenMode) {
+                        closeElem.style.display = "none";
+                        fullscreenElm.style.display = "none";
+                        preElm.style.padding = "0";
+                        editorElem.style.height = "calc( 100vh - 4px )";
+                        editorElem.style.width = "50%";
+                        editorElem.style.display = "inline-block";
+                        outputElem.style.width = "50%";
+                        outputElem._oldHeight = outputElem.style.height;
+                        outputElem.style.height = "calc( 100vh - 4px )";
+                        outputElem.style.minHeight = "calc( 100vh - 4px )";
+                        outputElem.style.display = "inline-block";
+                        statusElem.style.top = null
+                        statusElem.style.bottom = "1px";
+                    } else {
+                        closeElem.style.display = "inline-block";
+                        fullscreenElm.style.display = "inline-block";
+                        preElm.style.padding = "3px";
+                        delete outputElem.style.minHeight;
+                        editorElem.style.height = preElm.pluginConfig.editor_height || "600px";
+                        editorElem.style.width = "100%";
+                        editorElem.style.display = "block";
+                        outputElem.style.width = "100%";
+                        outputElem.style.height = outputElem._oldHeight || '600px';
+                        outputElem.style.display = "block";
+                        statusElem.style.bottom = null
+                        const editorHeight = parseInt(preElm.pluginConfig.editor_height || "600px")
+                        statusElem.style.top = `${editorHeight - 20}px`;
+                        preElm.scrollIntoView();
+                    }
+                    return
+                }
+                const outputElem = document.getElementById('output_' + id);
+                if (e.target === outputElem) {
+                    if (fullScreenMode) {
+                        outputElem.style.width = "100%";
+                        outputElem._oldHeight = outputElem.style.height;
+                        outputElem.style.height = "calc( 100vh - 4px )";
+                        outputElem.style.display = "block";
+                        if(outputElem.children.length === 1 && outputElem.children[0])outputElem.children[0].style.height = "100%";
+                    } else {
+                        outputElem.style.width = "100%";
+                        outputElem.style.height = outputElem._oldHeight || '600px';
+                        outputElem.style.display = "block";
+                        if(outputElem.children.length === 1 && outputElem.children[0]) outputElem.children[0].style.height = null
+                        outputElem.scrollIntoView();
+                    }
+                }
+            });
+        } catch (err) {
+            console.error("docsify-run-code: ".concat(err));
+        }
+    }
+
+    function initializeRunButtons() {
+        var targetElms = Array.apply(null, document.querySelectorAll("pre"));
+
+        var template = ['<button class="docsify-run-button">', '<span class="label">'.concat(i18n.runButtonText, "</span>"), "</button>",
+            '<button class="docsify-edit-button">', '<span class="label">'.concat(i18n.editButtonText, "</span>"), "</button>",
+            '<div class="docsify-loader"></div>',
+            '<button class="fullscreen-button" style="position:absolute; right:0px">+</button>'
+        ].join("");
+
+        targetElms.forEach(function (elm) {
+            try {
+                let tmp = elm.previousSibling.previousSibling;
+                if (!tmp || tmp.nodeName !== "#comment" || !tmp.nodeValue.trim().startsWith("ImJoyPlugin")) {
+                    // in case there is no empty line
+                    // the comment will be nested in the previous sibling
+                    if (tmp.childNodes[tmp.childNodes.length - 1].nodeName === "#comment") {
+                        tmp = tmp.childNodes[tmp.childNodes.length - 1]
+                        if (!tmp.nodeValue.trim().startsWith("ImJoyPlugin")) return;
+                    }
+                    else {
+                        return
+                    }
+                }
+                const ctrlStr = tmp.nodeValue.trim()
+                if (ctrlStr === 'ImJoyPlugin') {
+                    elm.pluginConfig = {};
+                } else {
+                    elm.pluginConfig = JSON.parse(ctrlStr.split(':').slice(1).join(":") || "{}");
+                }
+                elm.insertAdjacentHTML("beforeEnd", template);
+
+                elm.querySelector(".docsify-loader").style.display = "none";
+                elm.querySelector(".fullscreen-button").style.display = "none";
+                elm.style.position = 'relative';
+
+                const codeElm = elm.querySelector("code");
+                codeElm.insertAdjacentHTML('beforeBegin', `<div class="show-code-button">+ show source code</div>`);
+                const showCodeBtn = elm.querySelector('.show-code-button');
+                showCodeBtn.onclick = () => {
+                    codeElm.style.display = 'block';
+                    showCodeBtn.style.display = 'none';
+                }
+                if (elm.pluginConfig.hide_code_block) {
+
+                    codeElm.style.display = 'none';
+                } else {
+                    showCodeBtn.style.display = 'none'
+                }
+                if (elm.pluginConfig.startup_mode) {
+                    const mode = elm.pluginConfig.startup_mode;
+                    execute(elm, mode, true)
+                    delete elm.pluginConfig.startup_mode
+                }
+
+
+            } catch (e) {
+                console.error(e)
+            }
+
+        });
+
+        document.body.addEventListener("click", function (evt) {
+            const isRunCodeButton = evt.target.classList.contains("docsify-run-button");
+            const isEditCodeButton = evt.target.classList.contains("docsify-edit-button");
+            if (isRunCodeButton || isEditCodeButton) {
+                var buttonElm = evt.target.tagName === "BUTTON" ? evt.target : evt.target.parentNode;
+                const mode = isEditCodeButton ? "edit" : "run";
+                execute(buttonElm.parentNode, mode)
+            }
+        });
+    }
+
+    loadImJoyBasicApp({
+        process_url_query: true,
+        show_window_title: false,
+        show_progress_bar: true,
+        show_empty_window: true,
+        menu_style: { position: "absolute", right: "10px", top: "74px" },
+        window_style: { width: '100%', height: '100%' },
+        main_container: null,
+        menu_container: "menu-container",
+        window_manager_container: null, // "window-container",
+        imjoy_api: {
+            async createWindow(_plugin, config) {
+                let output;
+                if (_plugin && _plugin.config.namespace) {
+                    if (_plugin.config.namespace) {
+                        const outputContainer = document.getElementById('output_' + _plugin.config.namespace)
+                        if (!config.dialog && (!config.window_id || !document.getElementById(config.window_id))) {
+                            output = document.createElement('div')
+                            output.id = randId();
+                            output.classList.add('imjoy-window');
+                            outputContainer.style.height = "600px";
+                            outputContainer.appendChild(output)
+                            config.window_id = output.id
+                        }
+                    }
+                }
+                let w;
+                // fallback to grid
+                if (config.type && config.type.startsWith('imjoy/') || config.type === 'joy') {
+                    const grid = await imjoy.pm.createWindow(_plugin, {
+                        src: "https://grid.imjoy.io/#/app",
+                        window_id: config.window_id,
+                        namespace: config.namespace
+                    })
+                    w = await grid.createWindow(config);
+                } else {
+                    w = await imjoy.pm.createWindow(_plugin, config)
+                }
+
+                return w
+            }
+        } // override some imjoy API functions here
+    }).then(async app => {
+        // get the api object from the root plugin
+        const api = app.imjoy.api;
+        window.imjoy = app.imjoy;
+        // if you want to let users to load new plugins, add a menu item
+        app.addMenuItem({
+            label: "➕ Load Plugin",
+            callback() {
+                const uri = prompt(
+                    `Please type a ImJoy plugin URL`,
+                    "https://raw.githubusercontent.com/imjoy-team/imjoy-plugins/master/repository/welcome.imjoy.html"
+                );
+                if (uri) {
+                    app.loadPlugin(uri).then((plugin) => {
+                        app.runPlugin(plugin)
+                    })
+                }
+            },
+        });
+        app.addMenuItem({
+            label: "🧩 ImJoy Fiddle",
+            async callback() {
+                const plugin = await app.loadPlugin("https://if.imjoy.io")
+                await app.runPlugin(plugin)
+                app.removeMenuItem("🧩 ImJoy Fiddle")
+            },
+        });
+
+        app.imjoy.pm
+            .reloadPluginRecursively({
+                uri: "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.imjoy.html"
+            })
+            .then(enginePlugin => {
+                const queryString = window.location.search;
+                const urlParams = new URLSearchParams(queryString);
+                const engine = urlParams.get("engine");
+                const spec = urlParams.get("spec");
+                if (engine) {
+                    enginePlugin.api
+                        .createEngine({
+                            name: "MyCustomEngine",
+                            nbUrl: engine,
+                            url: engine.split("?")[0]
+                        })
+                        .then(() => {
+                            console.log("Jupyter Engine connected!");
+                        })
+                        .catch(e => {
+                            console.error("Failed to connect to Jupyter Engine", e);
+                        });
+                } else {
+                    enginePlugin.api
+                        .createEngine({
+                            name: "MyBinder Engine",
+                            url: "https://mybinder.org",
+                            spec: spec || "oeway/imjoy-binder-image/master"
+                        })
+                        .then(() => {
+                            console.log("Binder Engine connected!");
+                        })
+                        .catch(e => {
+                            console.error("Failed to connect to MyBinder Engine", e);
+                        });
+                }
+            });
+
+        initializeRunButtons();
+    });
+
+})();

--- a/assets/js/imjoy-app.js
+++ b/assets/js/imjoy-app.js
@@ -567,7 +567,17 @@
             }
         });
     }
-
+    const menuElem = document.createElement('div');
+    menuElem.id = "menu-container";
+    document.body.appendChild(menuElem);
+    const stylePatch = document.createElement('style');
+    stylePatch.textContent = `
+    .imjoy-dialog-control {
+        padding: 0px;
+        line-height: 10px;
+        color: white!important;
+    }`;
+    document.head.append(stylePatch);
     loadImJoyBasicApp({
         process_url_query: true,
         show_window_title: false,


### PR DESCRIPTION
This PR enables ImJoy plugin support for running ImageJ.JS (and potentially other software) interactively in the wiki.

![imagej js-interctive-docs](https://user-images.githubusercontent.com/478667/122206195-61c09680-cea1-11eb-90c0-9f34e8d7ce64.gif)


You can easily turn a markdown code block into executable and editable code block by: 
 1. Set `imjoy: true` to the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
 2. Add a comment `<!-- ImJoyPlugin: { ... } -->` before your code block. Inside the `{}` you can pass settings for setting up the ImJoy plugin.
 
For example:
````markdown
<!-- ImJoyPlugin: { "type": "macro"} -->
```javascript
print("hello");
```
````

To make it editable immediately, you can set `startup_mode` to `"edit"`:
````markdown
<!-- ImJoyPlugin: { "type": "macro", "startup_mode": "edit", "editor_height": "100px"} -->
```javascript
print("hello");
```
````

For more detailed usage, please refer to [ImJoy Docs](https://imjoy-team.github.io/imjoy-docs/#/).

Future extension includes supporting native Fiji/ImageJ running remotely on e.g. mybinder.org and and used for building interactive docs for ImageJ2/SciJava scripts.