### PR TITLE
Support extensions

### DIFF
--- a/_includes/extensions/imjoy
+++ b/_includes/extensions/imjoy
@@ -1,0 +1,2 @@
+<script src="https://lib.imjoy.io/imjoy-loader.js"></script>
+<script src="/assets/js/imjoy-app.js"></script>

--- a/_includes/extensions/mathjax
+++ b/_includes/extensions/mathjax
@@ -1,0 +1,3 @@
+<script type="text/javascript" async
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=default">
+</script>

--- a/_includes/layout/scripts
+++ b/_includes/layout/scripts
@@ -6,15 +6,10 @@
 <script src="/assets/js/util.js"></script>
 <script src="/assets/js/jquery.toc.js"></script>
 <script src="/assets/js/lightbox.min.js"></script>
-{% if page.usemathjax %}
-<script type="text/javascript" async
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=default">
-</script>
-{% endif %}
-{% if page.imjoy %}
-<script src="https://lib.imjoy.io/imjoy-loader.js"></script>
-<script src="/assets/js/imjoy-app.js"></script>
-{% endif %}
+<!-- Extensions -->
+{% for extension in page.extensions %}
+{% include extensions/{{ extension }} %}
+{% endfor %}
 <!-- Site code -->
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/dock.js"></script>

--- a/_pages/editing/advanced.md
+++ b/_pages/editing/advanced.md
@@ -61,6 +61,20 @@ content of the new page can be populated with a text editor of your choosing.
   changes pushes your edits to the main branch of the repository hosted on
   `GitHub`. The process of commiting is described below.
 
+
+## Create an extension
+If you want to extend the features of the wiki, for example, load a custom javascript library to certain pages.
+You can add your scripts into `_includes/extensions`, and then the user can enable your extension by adding the extension name to `extensions` in the [Front Matter](https://jekyllrb.com/docs/front-matter/) of their markdown file.
+
+For example, you can find two example extensions `mathjax` and `imjoy` in the `_includes/extensions` folder.
+And in the begining of any page, you can enable them by:
+```yaml
+---
+title: My Awesome Page
+extensions: ["imjoy", "mathjax"]
+---
+```
+
 ## Pushing, pulling, and commiting with Git
 
 Once you are ready to publish your your new page you will need to add, commit,

--- a/_pages/editing/math.md
+++ b/_pages/editing/math.md
@@ -2,7 +2,7 @@
 title: Math Expressions
 section: Contribute:Editing the Wiki
 nav-links: true
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 This page demonstrates how to include mathematical expressions.
@@ -13,11 +13,11 @@ Individual pages can opt-in to supporting mathematical notation using
 
 Processing a page with MathJax can take a few seconds, so it is not enabled by
 default on all pages.If you want to use MathJax, you must enable it in the
-[front matter](/editing#add-the-pages-front-matter) of your page:
+[front matter](/editing#add-the-pages-front-matter) of your page (i.e. add `"mathjax"` to `extensions`:
 
 ```
 ---
-usemathjax: true
+extensions: ["mathjax"]
 ---
 ```
 

--- a/_pages/imaging/deconvolution.md
+++ b/_pages/imaging/deconvolution.md
@@ -2,7 +2,7 @@
 title: Deconvolution
 section: Learn:Scientific Imaging
 nav-links: true
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 {% include wikipedia title='Deconvolution' text='Deconvolution'%} corrects the systematic error of blur (loss of contrast in smaller features) in optical systems such as fluorescence microscopy images.

--- a/_pages/learn/faq.md
+++ b/_pages/learn/faq.md
@@ -3,7 +3,7 @@ title: Frequently Asked Questions
 section: Learn:ImageJ Basics
 nav-links: true
 nav-title: FAQ
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 This page lists answers to the most frequently asked questions.

--- a/_pages/libs/imagej-ops/deconvolution.md
+++ b/_pages/libs/imagej-ops/deconvolution.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Ops_Deconvolution
 title: Ops Deconvolution
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/3d-viewer/user-faqs.md
+++ b/_pages/plugins/3d-viewer/user-faqs.md
@@ -2,7 +2,7 @@
 title: 3D Viewer › User FAQs
 nav-links: true
 nav-title: User FAQs
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Basic Usage

--- a/_pages/plugins/anisotropic-diffusion-2d.md
+++ b/_pages/plugins/anisotropic-diffusion-2d.md
@@ -4,7 +4,7 @@ title: Anisotropic Diffusion 2D
 categories: [Filtering]
 artifact: sc.fiji:Anisotropic_Diffusion_2D
 doi: 10.1109/TPAMI.2005.87
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 This plugin implement the anisotropic diffusion filter in 2D. Anisotropic filters are a class of filter that reduces noise in an image while trying to preserve sharp edges. See also [this page of the ImageJ 1.x web site](https://imagej.nih.gov/ij/plugins/anisotropic-diffusion-2d.html).

--- a/_pages/plugins/anomalous-diffusion-filters.md
+++ b/_pages/plugins/anomalous-diffusion-filters.md
@@ -2,7 +2,7 @@
 mediawiki: Anomalous_Diffusion_Filters
 title: Anomalous Diffusion Filters
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/bigstitcher/boundingbox.md
+++ b/_pages/plugins/bigstitcher/boundingbox.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_BoundingBox
 title: BigStitcher BoundingBox
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 If you want to fuse or deconvolve a sub-volume of your dataset (other than *all views* or the *currently selected views*), you have to specify that volume by defining a **Bounding Box**.

--- a/_pages/plugins/bigstitcher/brightnesscontrastadjustment.md
+++ b/_pages/plugins/bigstitcher/brightnesscontrastadjustment.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_BrightnessContrastAdjustment
 title: BigStitcher BrightnessContrastAdjustment
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Overview

--- a/_pages/plugins/bigstitcher/deconvolution.md
+++ b/_pages/plugins/bigstitcher/deconvolution.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_Deconvolution
 title: BigStitcher Deconvolution
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Overview

--- a/_pages/plugins/bigstitcher/flatfield-correction.md
+++ b/_pages/plugins/bigstitcher/flatfield-correction.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_Flatfield_correction
 title: BigStitcher Flatfield correction
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ### Overview

--- a/_pages/plugins/bigstitcher/frc.md
+++ b/_pages/plugins/bigstitcher/frc.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_FRC
 title: BigStitcher FRC
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Overview

--- a/_pages/plugins/bigstitcher/icp-refinement.md
+++ b/_pages/plugins/bigstitcher/icp-refinement.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_ICP_refinement
 title: BigStitcher ICP refinement
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 The default stitching pipeline of BigStitcher will calculate a **translational alignment** of your images. In some cases, however, there might also be more complex transformations (such as rotations between tiles or scaling between channels due to **chromatic aberrations**) between the images. To account for such **affine transformations** between the images, we offer the possibility to **Refine the Alignment** using the **ICP (Iterative Closest Point)** algorithm combined with global optimization.

--- a/_pages/plugins/bigstitcher/index.md
+++ b/_pages/plugins/bigstitcher/index.md
@@ -2,7 +2,7 @@
 mediawiki: BigStitcher
 title: BigStitcher
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/bigstitcher/interest-points.md
+++ b/_pages/plugins/bigstitcher/interest-points.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_Interest_points
 title: BigStitcher Interest points
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Overview

--- a/_pages/plugins/bigstitcher/registration.md
+++ b/_pages/plugins/bigstitcher/registration.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_Registration
 title: BigStitcher Registration
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 After you have [detected interest points](/plugins/bigstitcher/interest-points) in your images, you can proceed to register them. In **MultiView mode**, select the views to be registered, right-click and choose {% include bc path='Processing|Register using Interest Points...'%}.

--- a/_pages/plugins/bigstitcher/reorientsample.md
+++ b/_pages/plugins/bigstitcher/reorientsample.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: BigStitcher_ReorientSample
 title: BigStitcher ReorientSample
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 In addition to the manual view alignment functionality in **Stitching mode** (see [here](/plugins/bigstitcher/manual-translation) for details), which focuses on the translational alignment of tiled images, we offer offer complementary functions for **manually transforming** images and **managing transformations** in **MultiView mode**.

--- a/_pages/plugins/bonej.md
+++ b/_pages/plugins/bonej.md
@@ -5,7 +5,7 @@ categories: [Analysis, Mathematical Morphology, Particle Analysis]
 logo: /media/logos/bonej.png
 artifact: org.bonej:bonej-plugins
 doi: 10.12688/wellcomeopenres.16619.2
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 BoneJ is a collection of skeletal biology plug-ins for ImageJ. This documentation is for the current BoneJ version available through the ImageJ [updater](/plugins/updater). Legacy documentation is provided for old versions (1.x) at [bonej.org](https://bonej.org/).

--- a/_pages/plugins/bunwarpj.md
+++ b/_pages/plugins/bunwarpj.md
@@ -3,7 +3,7 @@ mediawiki: BUnwarpJ
 title: BUnwarpJ
 categories: [Registration]
 artifact: sc.fiji:bUnwarpJ_
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 {\| \|style="vertical-align:top" \|<img src="/media/plugins/bunwarpj-scheme.png" title="fig:bUnwarpJ scheme: bidirectional Unwarping in Java." width="390" alt="bUnwarpJ scheme: bidirectional Unwarping in Java." /> \|}

--- a/_pages/plugins/classic-watershed.md
+++ b/_pages/plugins/classic-watershed.md
@@ -2,7 +2,7 @@
 mediawiki: Classic_Watershed
 title: Classic Watershed
 categories: [Segmentation, Mathematical Morphology]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/csim-lab.md
+++ b/_pages/plugins/csim-lab.md
@@ -3,7 +3,7 @@ mediawiki: CSIMLab
 title: CSIMLab
 section: Contribute:Organizations
 categories: [Filtering,Noise]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/diameterj.md
+++ b/_pages/plugins/diameterj.md
@@ -2,7 +2,7 @@
 mediawiki: DiameterJ
 title: DiameterJ
 categories: [Analysis]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/directionality.md
+++ b/_pages/plugins/directionality.md
@@ -3,7 +3,7 @@ mediawiki: Directionality
 title: Directionality
 categories: [Analysis]
 artifact: sc.fiji:Directionality_
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
  

--- a/_pages/plugins/distance-transform-watershed.md
+++ b/_pages/plugins/distance-transform-watershed.md
@@ -2,7 +2,7 @@
 mediawiki: Distance_Transform_Watershed
 title: Distance Transform Watershed
 categories: [Segmentation, Mathematical Morphology]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/flimj.md
+++ b/_pages/plugins/flimj.md
@@ -2,7 +2,7 @@
 mediawiki: FLIMJ
 title: FLIMJ
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/hough-circle-transform.md
+++ b/_pages/plugins/hough-circle-transform.md
@@ -2,7 +2,7 @@
 mediawiki: Hough_Circle_Transform
 title: Hough Circle Transform
 categories: [Analysis]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/ij-blob.md
+++ b/_pages/plugins/ij-blob.md
@@ -3,7 +3,7 @@ mediawiki: IJ_Blob
 title: IJ Blob
 doi: 10.5334/jors.ae
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/integral-image-filters.md
+++ b/_pages/plugins/integral-image-filters.md
@@ -2,7 +2,7 @@
 mediawiki: Integral_Image_Filters
 title: Integral Image Filters
 categories: [Filtering,Integral Image]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/interactive-watershed.md
+++ b/_pages/plugins/interactive-watershed.md
@@ -2,7 +2,7 @@
 mediawiki: Interactive_Watershed
 title: Interactive Watershed
 categories: [Segmentation]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/level-sets.md
+++ b/_pages/plugins/level-sets.md
@@ -3,7 +3,7 @@ mediawiki: Level_Sets
 title: Level Sets
 categories: [Uncategorized]
 artifact: sc.fiji:level_sets
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 <img src="/media/plugins/ls.2b.progress.png" width="300"/>

--- a/_pages/plugins/morpholibj.md
+++ b/_pages/plugins/morpholibj.md
@@ -4,7 +4,7 @@ title: MorphoLibJ
 categories: [Analysis, Filtering, Segmentation, Mathematical Morphology]
 doi: 10.1093/bioinformatics/btw413
 artifact: fr.inra.ijpb:MorphoLibJ_
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/noise-generator.md
+++ b/_pages/plugins/noise-generator.md
@@ -2,7 +2,7 @@
 mediawiki: Noise_Generator
 title: Noise Generator
 categories: [Noise]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/pqct.md
+++ b/_pages/plugins/pqct.md
@@ -2,7 +2,7 @@
 mediawiki: PQCT
 title: PQCT
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/ridge-detection.md
+++ b/_pages/plugins/ridge-detection.md
@@ -2,7 +2,7 @@
 mediawiki: Ridge_Detection
 title: Ridge Detection
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 {% include warning/unmaintained %}

--- a/_pages/plugins/robust-clump-splitting.md
+++ b/_pages/plugins/robust-clump-splitting.md
@@ -2,7 +2,7 @@
 mediawiki: Robust_clump_splitting
 title: Robust clump splitting
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/shape-filter.md
+++ b/_pages/plugins/shape-filter.md
@@ -2,7 +2,7 @@
 mediawiki: Shape_Filter
 title: Shape Filter
 categories: [Uncategorized]
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 

--- a/_pages/plugins/spim-registration/method.md
+++ b/_pages/plugins/spim-registration/method.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: SPIM_Registration_Method
 title: SPIM Registration Method
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Citation

--- a/_pages/plugins/trackmate/algorithms.md
+++ b/_pages/plugins/trackmate/algorithms.md
@@ -1,7 +1,7 @@
 ---
 title: TrackMate Algorithms
 description: Description of the algorithms shipped in TrackMate.
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 This page documents the current components of [TrackMate](/plugins/trackmate). TrackMate has a modular design, meaning that it is made of different modules that each have a specific role. Developers can build their own module and re-used the other ones and the GUI to achieve a quick development. The module types are (in the order you meet them when executing the plugin):

--- a/_pages/plugins/trainable-segmentation/implementation.md
+++ b/_pages/plugins/trainable-segmentation/implementation.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Trainable_Segmentation_Plugin_Implementation
 title: Trainable Segmentation Plugin Implementation
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 <div style="background:#fdd; padding: 10px 10px 0 10px; border: 1px solid black;">

--- a/_pages/plugins/tws/index.md
+++ b/_pages/plugins/tws/index.md
@@ -4,7 +4,7 @@ title: Trainable Weka Segmentation
 categories: [Segmentation,Machine Learning]
 artifact: sc.fiji:Trainable_Segmentation
 doi: 10.1093/bioinformatics/btx180
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 {% include img align="center" name="fig:Trainable Weka Segmentation pipeline overview." src="tws-pipeline" width="600px" %}

--- a/_pages/plugins/tws/rand-error.md
+++ b/_pages/plugins/tws/rand-error.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Rand_error
 title: Rand error
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 The {% include wikipedia title='Rand index' text='Rand index'%} is a well-known measure of the similarity between two data clusterings[^1]. Recently, it has been proposed as a **measure of segmentation performance**, since a segmentation can be regarded as a clustering of pixels[^2]. More formally, define a segmentation as an integer-valued labeling of an image. Each object in a segmentation consists of a set of pixels sharing a common label.

--- a/_pages/plugins/tws/scripting.md
+++ b/_pages/plugins/tws/scripting.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Scripting_the_Trainable_Weka_Segmentation
 title: Scripting the Trainable Weka Segmentation
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 [Scripting](/scripting/script-editor) is one of the reasons Fiji is so powerful, and the Trainable Weka Segmentation library (that includes the [ Trainable Weka Segmentation plugin](/plugins/tws)) is one of the best examples for scriptable Fiji components.

--- a/_pages/plugins/tws/topology-preserving-warping-error.md
+++ b/_pages/plugins/tws/topology-preserving-warping-error.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Topology_preserving_warping_error
 title: Topology preserving warping error
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 {% include thumbnail src='/media/plugins/tws/warping-error-comparison.png' title='Application of the topology-preserving warping error. Example A and B have almost the same amount of pixel error with respect to the ground truth, however, example B has no topological error.'%} The **warping error** is a [segmentation](/imaging/segmentation) metric that tolerates disagreements over boundary location, penalizes topological disagreements, and can be used directly as a cost function for learning boundary detection[^1].

--- a/_pages/scripting/clojure.md
+++ b/_pages/scripting/clojure.md
@@ -2,7 +2,7 @@
 mediawiki: Clojure_Scripting
 title: Clojure Scripting
 section: Extend:Scripting:Languages
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 {% include wikipedia title='Clojure' text='Clojure'%} is a dialect of the {% include wikipedia title='Lisp (programming language)' text='Lisp programming language'%}. Clojure is a general-purpose programming language with an emphasis on functional programming.

--- a/_pages/software/imagej-js.md
+++ b/_pages/software/imagej-js.md
@@ -1,7 +1,7 @@
 ---
 title: ImageJ.JS
 section: Explore:Software
-imjoy: true
+extensions: ["imjoy"]
 ---
 
 ImageJ.JS is web version of ImageJ, we compiled ImageJ (version 1) from Java into Javascript with a Java compiler called [CheerpJ](https://www.leaningtech.com/pages/cheerpj.html). In addition to the modification for making it work better within the browser, importantly, we integrated it with the [ImJoy](https://imjoy.io) plugin ecosystem. The project is currently under active development within the [ImJoy Team](https://github.com/imjoy-team) led by Wei Ouyang.
@@ -64,10 +64,18 @@ run("Analyze Particles...", "size=5-Infinity add");
 
 # Run ImageJ.JS and ImJoy in ImageJ wiki
 You can easily turn a markdown code block into executable and editable code block by: 
- 1. Set `imjoy: true` to the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
+ 1. Set add `"imjoy"` to `extensions` in the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
  2. Add a comment `<!-- ImJoyPlugin: { ... } -->` before your code block. Inside the `{}` you can pass settings for setting up the ImJoy plugin.
  
-For example the above code block is rendered from:
+For example, you may have the following in the begining of your page:
+```yaml
+---
+title: My Awesome Page
+extensions: ["imjoy"]
+---
+```
+
+And now, whthin the page, you can use the following to add a executable and editable code block:
 ````markdown
 <!-- ImJoyPlugin: { "type": "macro"} -->
 ```javascript

--- a/_pages/software/imjoy.md
+++ b/_pages/software/imjoy.md
@@ -2,7 +2,7 @@
 title: ImJoy
 section: Explore:Software
 doi: 10.1038/s41592-019-0627-0
-imjoy: true
+extensions: ["imjoy"]
 ---
 
 # ImJoy: Supercharging interactivity and scalability of data science!
@@ -90,10 +90,17 @@ Here is a list of integration examples:
 
 # Running ImJoy plugins in the ImageJ wiki
 As another example of open integration, ImJoy can be enabled in the ImageJ wiki. In any markdown page, you can easily turn a markdown code block into executable and editable code block by: 
- 1. Set `imjoy: true` to the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
+ 1. Set add `"imjoy"` to `extensions` in the metadata of your markdown file (a.k.a [Front Matter](https://jekyllrb.com/docs/front-matter/));
  2. Add a comment `<!-- ImJoyPlugin: { ... } -->` before your code block. Inside the `{}` you can pass settings for setting up the ImJoy plugin.
-
-For example, the following code block with Run button is rendered with the above setting:
+ 
+For example, you may have the following in the begining of your page:
+```yaml
+---
+title: My Awesome Page
+extensions: ["imjoy"]
+---
+```
+Within your page, the following code block with Run button is rendered with the above setting:
 <!-- ImJoyPlugin: { "type": "web-worker","editor_height": "200px"} -->
 ```js
 api.alert("Hello from ImJoy!")

--- a/_pages/tutorials/correcting-drift-in-frap-experiments.md
+++ b/_pages/tutorials/correcting-drift-in-frap-experiments.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Correcting_drift_in_FRAP_experiments
 title: Correcting drift in FRAP experiments
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 <i>This tutorial is brought to you by Joao Firmino, Knust lab, MPI-CBG. It relates how to correct for the drift of your biological samples during long-term timelapse imaging for subsequent analysis using Fiji. Comments on the content of this tutorial [are welcome](/discuss/#ways-to-get-help). </i>

--- a/_pages/tutorials/generate-and-exploit-kymographs.md
+++ b/_pages/tutorials/generate-and-exploit-kymographs.md
@@ -1,7 +1,7 @@
 ---
 mediawiki: Generate_and_exploit_Kymographs
 title: Generate and exploit Kymographs
-usemathjax: true
+extensions: ["mathjax"]
 ---
 
 ## Introduction


### PR DESCRIPTION
This PR implements the `extensions` idea proposed by @ctrueden in https://github.com/imagej/imagej.github.io/pull/175#issuecomment-862782175

The idea is to allow future scripts added into `includes/extensions` and used by adding `extensions: [mathjax, imjoy]` into the front matter.

Here is the docs I added to `Advanced Editing`
## Create an extension
If you want to extend the features of the wiki, for example, load a custom javascript library to certain pages.
You can add your scripts into `_includes/extensions`, and then the user can enable your extension by adding the extension name to `extensions` in the [Front Matter](https://jekyllrb.com/docs/front-matter/) of their markdown file.

For example, you can find two example extensions `mathjax` and `imjoy` in the `_includes/extensions` folder.
And in the begining of any page, you can enable them by:
```yaml
---
title: My Awesome Page
extensions: ["imjoy", "mathjax"]
---
```
