### PR TITLE
Patch ImJoy extension for rouge syntax highlighter

### DIFF
--- a/assets/js/imjoy-app.js
+++ b/assets/js/imjoy-app.js
@@ -507,7 +507,12 @@
 
         targetElms.forEach(function (elm) {
             try {
-                let tmp = elm.previousSibling.previousSibling;
+                // patch for rouge syntax highlighter
+                if(elm.parentElement && elm.parentElement.parentElement && elm.parentElement.classList.contains('highlight')){
+                    elm = elm.parentElement.parentElement
+                }
+
+                let tmp = elm.previousSibling && elm.previousSibling.previousSibling;
                 if (!tmp || tmp.nodeName !== "#comment" || !tmp.nodeValue.trim().startsWith("ImJoyPlugin")) {
                     // in case there is no empty line
                     // the comment will be nested in the previous sibling


### PR DESCRIPTION
The ImJoy interactive code blocks are not working on github pages, and this issue is not seen in the local development because the rouge syntax highlighter was not enabled. This is a patch to detect code blocks decorated by rouge.