### PR TITLE
Add a `More...` menu for software and libraries

### DIFF
--- a/_includes/layout/menu
+++ b/_includes/layout/menu
@@ -246,6 +246,8 @@
                 <li><a href="/libs/imglib2/developing">Developing ImgLib2</a></li>
                 <li><a href="/libs/imglib2/discussion">ImgLib2 Discussion</a></li>
               {% include menu/section-end %} <!-- Explore/Libraries/ImgLib2 -->
+              
+              <li><a href="/libs">More...</a>
             {% include menu/section-end %} <!-- Explore/Libraries -->
 
             {% include menu/section title="Software" link="/software" %}
@@ -253,6 +255,7 @@
               <li><a href="/software/imagej-1.x">ImageJ 1.x</a>
               <li><a href="/software/imagej2">ImageJ2</a>
               <li><a href="/software/fiji">Fiji</a>
+              <li><a href="/software">More...</a>
             {% include menu/section-end %} <!-- Explore/Software -->
           {% include menu/section-end %} <!-- Explore -->
         </ul>


### PR DESCRIPTION
In the menu, if one only click the arrow button to explore the options, it's not obvious that all the other software or libraries items are listed in the root page, adding a `More...` menu would make it easy to explore the menu entries.