### PR TITLE
Add imagej.js links

### DIFF
--- a/_pages/downloads.md
+++ b/_pages/downloads.md
@@ -75,6 +75,8 @@ Still have questions? Ask on the [Image.sc Forum](https://forum.image.sc/tag/ima
 <details class="shadowed-box"><summary><strong>Need help deciding? Click here.</strong></summary>
 {{help-me-decide | markdownify}}
 </details>
+<div class="shadowed-box">💡 You can also try <a href="/software/imagej-js">ImageJ.JS</a> in your web browser: <a href="https://ij.imjoy.io" target="_blank">https://ij.imjoy.io</a>
+</div>
 
 # System requirements
 

--- a/_pages/software/imagej-js.md
+++ b/_pages/software/imagej-js.md
@@ -116,6 +116,19 @@ api.createWindow({ src: 'https://slides.imjoy.io/?slides=https://raw.githubuserc
 
 For more detailed usage, please refer to [ImJoy Slides](https://github.com/imjoy-team/imjoy-slides).
 
+
+# Integrate ImageJ.JS to your own website
+If you have a project page, website or online data repository which you would like to allow users to run ImageJ.JS, you can integrate ImageJ.JS to make your data and analysis workflow interactive. Since ImageJ.JS is also an [ImJoy](/software/imjoy) plugin, the recommend way to integrate ImageJ.JS is to load the ImJoy core to your site by following the [integration docs](https://github.com/imjoy-team/imjoy-core/blob/master/docs/integration.md), and then run the following code to instantiate ImageJ.JS:
+
+<!-- ImJoyPlugin: { "type": "web-worker", "editor_height": "400px"} -->
+```javascript
+async function run(){
+    const ij = await api.createWindow({src: "https://ij.imjoy.io"})
+    // call the imagej.js api, see https://github.com/imjoy-team/imagej.js
+}
+run()
+```
+
 # Citation
 
 ImageJ.JS is a part of the ImJoy project, please consider citing the ImJoy paper on Nature Methods ([https://www.nature.com/articles/s41592-019-0627-0](https://www.nature.com/articles/s41592-019-0627-0), [free access](https://rdcu.be/bYbGO) ):

--- a/_pages/software/imagej.md
+++ b/_pages/software/imagej.md
@@ -12,6 +12,7 @@ timeline-imagej:
 - 2008 | Fiji                  | TODO
 - 2009 | ImageJ2               | TODO
 - 2015 | ImageJFX              | TODO
+- 2020 | ImageJ.JS             | TODO
 ---
 
 
@@ -77,6 +78,16 @@ There are a few different flavors of ImageJ with very similar names, and some co
         with Maven without hassles.<br><br>It is what ImageJ2's legacy support
         uses at its core.</td>
       <td>Jul. 2005</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td><img src="https://ij.imjoy.io/assets/icons/chrome/chrome-installprocess-128-128.png" width="64"/></td>
+      <td><a href="/software/imagej-js">ImageJ.JS</a></td>
+      <td>{% include person id='oeway' %}</td>
+      <td>ImageJ.JS is a web version of <a href="/libs/imageja">ImageJA</a> that runs in the browser without installation,
+      compiled from Java to Javascript using the <a href="https://leaningtech.com/cheerpj/">Cheerpj compiler</a> and integrated with the <a href="/software/imjoy">ImJoy</a> plugin system. It's accessible from <a href="https://ij.imjoy.io">https://ij.imjoy.io</a> and also support mobile devices and tablets.
+      </td>
+      <td>2020</td>
       <td>Active</td>
     </tr>
     <tr>

--- a/_pages/software/imjoy.md
+++ b/_pages/software/imjoy.md
@@ -21,6 +21,8 @@ ImJoy is a plugin powered hybrid computing platform for deploying deep learning 
 
 The ImJoy project was started at Institut Pasteur in 2018. It is currently actively improved and maintained by the ImJoy Team led by Wei Ouyang (SciLifeLab & KTH in Stockholm). The team consists of members from different institutions who meet weekly and continuously improving the software and expanding the plugin ecosystem.
 
+The latest documentation with full details are avaiable at [https://imjoy.io/docs](https://imjoy.io/docs).
+
 # Getting started
 ImJoy is a progressive web application which you can run directly in your browser without installation. Go to [https://imjoy.io](https://imjoy.io) and click "Start ImJoy".
 


### PR DESCRIPTION
This PR add ImageJ.JS to the download and ImageJ page. Not sure what's the best way to show the ImageJ.JS in the download page, I am using a box for now, please let me know if you have any suggestion.