### PR TITLE
Update Update Site Uploads for Github Actions

### DIFF
--- a/_pages/update-sites/automatic-uploads.md
+++ b/_pages/update-sites/automatic-uploads.md
@@ -7,22 +7,100 @@ nav-links: true
 nav-title: Automatic Uploads
 ---
 
-{% include notice icon="info" content='This guide is intended for maintaining non-core update sites by automating builds with [Travis CI](https://travis-ci.org/).  
-- The [core update sites](/update-sites/core-uploads) are updated manually or by [Travis CI](/develop/travis).
-- Travis CI is useful because it can freely build any open source project with minimal effort.' %}
+{% include notice icon="info" content='This guide is intended for maintaining non-core update sites by automating builds with [GitHub Actions](https://docs.github.com/en/actions) or [Travis CI](https://travis-ci.org/).
+- The [core update sites](/update-sites/core-uploads) are updated manually or automatically. Automated update is performed with [GitHub Actions](https://docs.github.com/en/actions) since July 2021, before that [Travis CI](/develop/travis) was used.
+- GitHub Actions and Travis CI are useful because they can freely build any open source project with minimal effort.' %}
 
-# Requirements
+# GitHub Actions
+## Requirements
+
+-   An open-source project hosted on [GitHub](/develop/github)
+-   An [initialized upload password](/update-sites/setup#add-your-personal-update-sit).
+
+## Additional resources
+
+-   [GitHub Actions user guide](https://docs.github.com/en/actions/quickstart)
+
+## Automatic Uploads via GitHub Actions
+
+GitHub Actions can be used to automatically build a repository in response to code changes. To ease the maintenance of ImageJ update sites, we can use GitHub Actions to automatically upload the latest version of a site. This is done by creating a `.github/workflows/release.yml` file in your update site's GitHub repository that does the following:
+
+1.  Create a fresh ImageJ.app
+2.  Build the update site's repository and move the required artifacts (e.g. `.jars`) to their intended locations in the ImageJ.app
+3.  Upload the local update site state to your Wiki update site
+
+As a starting point you can copy the following `.github/workflows/release.yml` :
+
+```yml
+name: Release to Update Site
+
+on:
+  push:
+    branches: [master]  # Trigger the workflow on push to the master branch
+
+jobs:
+  build_release:
+    runs-on: ubuntu-latest
+    env:
+      IJ_DOWNLOAD_URL: https://downloads.imagej.net/fiji/latest/fiji-linux64.tar.gz
+      WIKI_USER: YOUR_USER_NAME
+      UPDATE_PASS: ${{ secrets.UPDATE_PASS }}  # DO NOT WRITE your password here
+      UPDATE_SITE: YOUR_UPDATE_SITE_NAME
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build with Maven
+        run: mvn -B package
+      - name: Install ImageJ/Fiji
+        run: |
+          curl --silent ${IJ_DOWNLOAD_URL} | tar --extract --gzip
+          ./Fiji.app/ImageJ-linux64 --headless --update edit-update-site ${UPDATE_SITE} https://sites.imagej.net/${UPDATE_SITE}/ "webdav:${WIKI_USER}:${UPDATE_PASS}" .
+      - name: Install in ImageJ/Fiji (with Maven)
+        run: mvn -B install -Dscijava.app.directory=./Fiji.app -Ddelete.other.versions=true -Dscijava.ignoreDependencies=true
+      - name: Release to ImageJ update site
+        run: |
+          ./Fiji.app/ImageJ-linux64 --headless --update upload-complete-site --force ${UPDATE_SITE}
+```
+
+Don't forget to replace the `WIKI_USER` and `UPDATE_SITE` variables by your informations.
+
+### Encrypting your password
+
+To upload to your wiki update site, you will need to provide GitHub Actions with a `UPDATE_PASS` environment variable, which should evaluate to the [upload password](/update-sites/setup#add-your-personal-update-site) of the Wiki account performing the upload. To do so securely, follow the instructions on [creating encrypted secrets for a repository](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+### Non-Mavenized Files
+
+GitHub Actions is capable of building many languages besides Java. If you cannot use Maven with a `scijava.app.directory` then you need to replace the following line of your `.github/workflows/release.yml`:
+
+      - `mvn -B install -Dscijava.app.directory=./Fiji.app -Ddelete.other.versions=true -Dscijava.ignoreDependencies=true`
+
+with a sequence of commands that will move your build artifacts to the appropriate `./Fiji.app/jars` or `./Fiji.app/plugins` directory, as appropriate for your update site.
+
+This is also true if you have custom scripts, macros, etc... if these files are not present in the correct locations of the local ImageJ.app, they will appear to have been deleted.
+
+## Caveats
+
+{% include notice icon="warning" content="**USE CAUTION HERE**
+
+1.  You are configuring GitHub Actions to upload the state of an ImageJ installation to your update site. The ImageJ.app that will be uploaded is located at `./Fiji.app` with respect to the current working directory of the virtual machine GitHub Actions is running on. If your build artifacts are not located in the `./Fiji.app/jars` or `./Fiji.app/plugins` directory, or you don't manually copy scripts to the correct location, ImageJ will see these items as having been deleted—**effectively removing all content from your update site.** You can mitigate this danger by customizing your `release.yml` to download your own update site into the base ImageJ.app; only changes to the update site state will be uploaded.
+2.  By default—building the master branch of your repository—your update site will be updated with **every change** to the source code. Although we encourage the master branch to be \"[release ready](/develop/releasing#phase-2-on-master)\", a safer practice would be to configure GitHub Actions to [only build specific events](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)—and set it to build [release versions](/develop/architecture#reproducible-builds) only—e.g. with a release version integration branch.
+3.  Using the Maven-based `release.yml` as suggested implies that you are conforming to the managed dependencies of the parent pom.xml. If you are not staying up-to-date with the ImageJ and Fiji update sites (by using the latest ImageJ or Fiji [bill of materials](/develop/architecture#bill-of-materials)) then this automation may break your own update site." %}
+
+
+
+# Tarvis CI
+## Requirements
 
 -   An open-source project hosted on [GitHub](/develop/github)
 -   Logging in to [Travis CI](https://travis-ci.org/auth) with your corresponding GitHub account
 -   [Travis command line tools](https://github.com/travis-ci/travis.rb#installation)
 -   An [initialized upload password](/update-sites/setup#add-your-personal-update-sit).
 
-# Additional resources
+## Additional resources
 
 -   [Travis CI user guide](https://docs.travis-ci.com/user/getting-started/)
 
-# Automatic Uploads via Travis CI
+## Automatic Uploads via Travis CI
 
 Travis CI can be used to automatically build a repository in response to code changes. To ease the maintenance of ImageJ update sites, we can use Travis to automatically upload the latest version of a site. This is done by creating a `.travis.yml` file in your update site's GitHub repository that does the following:
 
@@ -92,7 +170,7 @@ export UPDATE_SITE="/update-sites"
 
 by your informations.
 
-## Encrypting your password
+### Encrypting your password
 
 To upload to your wiki update site, you will need to provide Travis CI with a `WIKI_UPLOAD_PASS` environment variable, which should evaluate to the [upload password](/update-sites/setup#add-your-personal-update-site) of the Wiki account performing the upload. To do so securely, follow the instructions on the [encrypting environment variables](https://docs.travis-ci.com/user/environment-variables/#Encrypting-Variables-Using-a-Public-Key).
 
@@ -104,7 +182,7 @@ $ travis encrypt WIKI_UPLOAD_PASS=super_secret --add env.matrix
 
 in your repository, the `.travis.yml` will automatically be updated appropriately. You can simply commit and push the changes.
 
-## Non-Mavenized Files
+### Non-Mavenized Files
 
 Travis CI is capable of building many languages besides Java. If you cannot use Maven with a `scijava.app.directory` then you need to replace the following line of your `.travis.yml`:
 
@@ -114,7 +192,7 @@ with a sequence of commands that will move your build artifacts to the appropria
 
 This is also true if you have custom scripts, macros, etc... if these files are not present in the correct locations of the local ImageJ.app, they will appear to have been deleted.
 
-# Caveats
+## Caveats
 
 {% include notice icon="warning" content="**USE CAUTION HERE**
 
@@ -122,6 +200,6 @@ This is also true if you have custom scripts, macros, etc... if these files are 
 2.  By default—building the master branch of your repository—your update site will be updated with **every change** to the source code. Although we encourage the master branch to be \"[release ready](/develop/releasing#phase-2-on-master)\", a safer practice would be to configure Travis CI to [only build specific branches](https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches)—and set it to build [release versions](/develop/architecture#reproducible-builds) only—e.g. with a release version integration branch.
 3.  Using the Maven-based `.travis.yml` as suggested implies that you are conforming to the managed dependencies of the parent pom.xml. If you are not staying up-to-date with the ImageJ and Fiji update sites (by using the latest ImageJ or Fiji [bill of materials](/develop/architecture#bill-of-materials)) then this automation may break your own update site." %}
 
-# See Also
+## See Also
 
 -   [Travis use](/develop/travis)


### PR DESCRIPTION
I duplicated the instructions for Tarvis CI automated uploads to update sites, adapting for GitHub Actions.
The document structure is exactly the same, the main change is the `.yml` configuration file which has to be used.

Please observe however that I had to modify the script that performs the release. In the (older) Tarvis CI section, the bash commands are:

    wget --no-check-certificate https://downloads.imagej.net/fiji/latest/fiji-linux64.zip  &&  unzip fiji-linux64.zip
    mvn clean install -Dscijava.app.directory=$IJ_PATH -Ddelete.other.versions=true
    $IJ_LAUNCHER --update edit-update-site $UPDATE_SITE $URL "webdav:$USER:$WIKI_UPLOAD_PASS" .
    $IJ_LAUNCHER --update update
    $IJ_LAUNCHER --update upload --update-site $UPDATE_SITE --force-shadow jars/YOUR-FILE.jar

whereas with GitHub Actions I suggest (adjusting slightly for readability here):

    curl --silent $IJ_DOWNLOAD_URL | tar --extract --gzip
    $IJ_LAUNCHER --update edit-update-site $UPDATE_SITE $URL "webdav:$USER:$WIKI_UPLOAD_PASS" .
    mvn -B install -Dscijava.app.directory=$IJ_PATH -Ddelete.other.versions=true -Dscijava.ignoreDependencies=true
    $IJ_LAUNCHER --update upload-complete-site --force $UPDATE_SITE

The reason I had to change is that when testing on my side, I figured the steps indicated in the Tarvis CI section create dependency conflicts. I am not sure my fix is adequate, but I would be more than happy to correct it!