### PR TITLE
Relink tutorials on imagej.net

### DIFF
--- a/_pages/develop/index.md
+++ b/_pages/develop/index.md
@@ -10,7 +10,7 @@ This page provides an overview of ImageJ2 from the perspective of software devel
 ## Quick start
 
 -   **Learn to write [scripts](/scripting)** from the [tutorial notebooks](/tutorials/notebooks).
--   **Learn to use ImageJ2 from Java** with the [tutorial Maven projects](https://github.com/imagej/tutorials/tree/master/maven-projects).
+-   **Learn to use ImageJ2 from Java** with the [tutorial Java projects](https://github.com/imagej/tutorials/tree/master/java).
 
 ## What is ImageJ2?
 

--- a/_pages/develop/maven.md
+++ b/_pages/develop/maven.md
@@ -125,7 +125,7 @@ There are many more things you can do with Maven, but chances are you will not n
 
 The simplicity of the `pom.xml` you need comes from the fact that Maven defines implicit defaults. It calls that *convention over configuration*. For many reasons, it is strongly recommended to stay with the defaults as much as possible.
 
-In the context of [SciJava](/libs/scijava), you will most likely never write a `pom.xml` from scratch. You will rather more likely edit an existing one, possibly after having copied it. We recommend using the [ImageJ "Load and Display a Dataset" tutorial](https://github.com/imagej/tutorials/tree/master/maven-projects/load-and-display-dataset) as a starting point.
+In the context of [SciJava](/libs/scijava), you will most likely never write a `pom.xml` from scratch. You will rather more likely edit an existing one, possibly after having copied it. We recommend using the [ImageJ "Load and Display a Dataset" tutorial](https://github.com/imagej/tutorials/blob/master/java/howtos/src/main/java/howto/datasets/LoadAndDisplayDataset.java) as a starting point.
 
 # How to find a dependency's groupId/artifactId/version (GAV)?
 

--- a/_pages/events/learnathon-2017.md
+++ b/_pages/events/learnathon-2017.md
@@ -68,7 +68,7 @@ Details of your assignment:
 
 -   Create a [Git](/develop/git) repository.
 -   Create a [Maven](/develop/maven) project. (hints: [1](https://github.com/imagej/example-imagej-command), [2](/develop/building-a-pom))
--   Implement a `Command` plugin in your [IDE](/develop/ides), which calculates the *mean* across an image. (hints: [1](https://nbviewer.jupyter.org/github/imagej/tutorials/blob/master/notebooks/1-Using-ImageJ/2-ImageJ-Ops.ipynb), [2](https://github.com/imagej/tutorials/tree/master/maven-projects/simple-commands/src/main/java))
+-   Implement a `Command` plugin in your [IDE](/develop/ides), which calculates the *mean* across an image. (hints: [1](https://nbviewer.jupyter.org/github/imagej/tutorials/blob/master/notebooks/1-Using-ImageJ/2-ImageJ-Ops.ipynb), [2](https://github.com/imagej/tutorials/tree/master/java/simple-commands/src/main/java))
 -   Push to [GitHub](/develop/github) (hints: [1](https://help.github.com/articles/pushing-to-a-remote/), [2](https://git-man-page-generator.lokaltog.net/)).
 
 If you get that far, YOU WIN. {% include person id='fjug' %} has a reward for you.
@@ -119,7 +119,7 @@ Git repos to clone:
     -   [`https://github.com/bigdataviewer/bigdataviewer-vistools.git`](https://github.com/bigdataviewer/bigdataviewer-vistools.git)
 -   Afternoon Ops Session:
     -   [`https://github.com/imagej/tutorials`](https://github.com/imagej/tutorials)
-        -   Import the `maven-projects/using-ops` into your IDE
+        -   Import the `1-Using-ImageJ/2-ImageJ-Ops.ipynb` into your IDE
     -   [Introduction to ImageJ Ops](https://nbviewer.jupyter.org/github/imagej/tutorials/blob/master/notebooks/1-Using-ImageJ/2-ImageJ-Ops.ipynb) Jupyter notebook
     -   [Extending ImageJ: Ops](https://nbviewer.jupyter.org/github/imagej/tutorials/blob/master/notebooks/2-Extending-ImageJ/2-Ops.ipynb) Jupyter notebook
 -   Afternoon Session on KNIME:

--- a/_pages/events/learnathon-2018.md
+++ b/_pages/events/learnathon-2018.md
@@ -109,7 +109,7 @@ The ImageJ Legacy Course covered the topics: images, tables, regions of interest
 ### Developing ImageJ Ops
 
 -   Clone https://github.com/imagej/tutorials (but you already have it, right?)
--   Import `maven-projects/create-a-new-op` in Eclipse.
+-   Import `java/howtos/src/main/java/howto/ops/CreateANewOp` in Eclipse.
 -   See also the [Adding new ops](/develop/writing-ops) guide
 -   See also the "Extending ImageJ: Ops" notebook linked from [here](/tutorials/notebooks)
 

--- a/_pages/events/learnathon-2019.md
+++ b/_pages/events/learnathon-2019.md
@@ -103,7 +103,7 @@ Slides can be found [here](https://bnorthan.github.io/viewing-images-tutorial/sl
 
 [ImageJ Tutorials](https://github.com/imagej/tutorials)
 
-[Widget-Demo](https://github.com/imagej/tutorials/tree/master/maven-projects/widget-demo) showing all different widgets for all available input @Parameters.
+[Widget-Demo](https://github.com/imagej/tutorials/blob/master/java/howtos/src/main/java/howto/ui/WidgetDemo.java) showing all different widgets for all available input @Parameters.
 
 [DoG Pyramid example.](https://github.com/tibuch/DoG_Pyramid)
 


### PR DESCRIPTION
There were a few more tutorial links that lead to 404s. I'm not certain if the older learnathon links really matter that much, but I re-linked them anyway. I used Jekyll to build the website so it doesn't crash anything. I did do a git rebase to place my commits on top of main, and looking at the history I'm pretty sure I did everything correctly, but I'm submitting a pull request to be safe. 