### PR TITLE
Add download links to Fiji releases from mirrors

### DIFF
--- a/_includes/fiji/download-links
+++ b/_includes/fiji/download-links
@@ -2,22 +2,52 @@
 <div>
 <table>
 <tbody>
-<tr><th colspan="3" style="font-size: large; text-align: center">~ Download Fiji for your OS ~</th></tr>
-<tr>
-<td style="text-align: center; vertical-align: top; width: 128px"> <a href="https://downloads.imagej.net/fiji/latest/fiji-win64.zip"><img alt="Windows (64-bit)" src="/media/icons/windows.svg" width="129" height="128"></a><br><a href="https://downloads.imagej.net/fiji/latest/fiji-win64.zip"><b>64-bit</b></a>
-</td>
-<td style="text-align: center; vertical-align: top; width: 128px"> <a href="https://downloads.imagej.net/fiji/latest/fiji-macosx.zip"><img alt="macOS" src="/media/icons/macos.png" width="105" height="128"></a><br><a href="https://downloads.imagej.net/fiji/latest/fiji-macosx.zip"><b>macOS (x86_64)</b></a>
-</td>
-<td style="text-align: center; vertical-align: top; width: 128px"> <a href="https://downloads.imagej.net/fiji/latest/fiji-linux64.zip"><img alt="Linux (64-bit)" src="/media/icons/linux.svg" width="128" height="128"></a><br><a href="https://downloads.imagej.net/fiji/latest/fiji-linux64.zip"><b>64-bit</b></a>
-</td>
-</tr>
-<tr><th colspan="3" style="text-align: center">Other downloads</th></tr>
-<tr>
-<td style="text-align: center"> <a href="https://downloads.imagej.net/fiji/latest/fiji-win32.zip"><img alt="Windows (32-bit)" src="/media/icons/windows.svg" width="24" height="24"></a> <a href="https://downloads.imagej.net/fiji/latest/fiji-win32.zip">32-bit</a>
-</td>
-<td colspan=2 style="text-align: center">  <a href="https://downloads.imagej.net/fiji/latest/fiji-nojre.zip"><img alt="All platforms (no JRE)" src="/media/icons/fiji.png" width="24" height="24"></a> <a href="https://downloads.imagej.net/fiji/latest/fiji-nojre.zip">No JRE</a>
-</td>
-</tr>
+  <tr>
+    <th colspan="3" style="font-size: large; text-align: center">~ Download Fiji for your OS ~</th>
+  </tr>
+
+  <tr>
+    <th rowspan="2"><img style="vertical-align:middle;" alt="Windows" src="/media/icons/windows.svg" width="24" height="24"></th>
+    <td>Windows 64-bit</td>
+    <td>
+      <a style="text-decoration: underline;" href="https://downloads.imagej.net/fiji/latest/fiji-win64.zip">imagej.net (USA)</a>,
+      <a style="text-decoration: underline;" href="https://downloads.micron.ox.ac.uk/fiji_update/mirrors/fiji-latest/fiji-win64.zip">micron.ox.ac.uk (European mirror)</a>
+    </td>
+  </tr>
+  <tr>
+    <td>Windows 32-bit</td>
+    <td>
+      <a style="text-decoration: underline;" href="https://downloads.imagej.net/fiji/latest/fiji-win32.zip">imagej.net (USA)</a>,
+      <a style="text-decoration: underline;" href="https://downloads.micron.ox.ac.uk/fiji_update/mirrors/fiji-latest/fiji-win32.zip">micron.ox.ac.uk (European mirror)</a>
+    </td>
+  </tr>
+
+  <tr>
+    <th><img alt="macOS" src="/media/icons/macos.png" width="24" height="24"></th>
+    <td>macOS (x86_64)</td>
+    <td>
+      <a style="text-decoration: underline;" href="https://downloads.imagej.net/fiji/latest/fiji-macosx.zip">imagej.net (USA)</a>,
+      <a style="text-decoration: underline;" href="https://downloads.micron.ox.ac.uk/fiji_update/mirrors/fiji-latest/fiji-macosx.zip">micron.ox.ac.uk (European mirror)</a>
+    </td>
+  </tr>
+
+  <tr>
+    <th><img alt="Linux" src="/media/icons/linux.svg" width="24" height="24"></th>
+    <td>Linux (64-bit)</td>
+    <td>
+      <a style="text-decoration: underline;" href="https://downloads.imagej.net/fiji/latest/fiji-linux64.zip">imagej.net (USA)</a>,
+      <a style="text-decoration: underline;" href="https://downloads.micron.ox.ac.uk/fiji_update/mirrors/fiji-latest/fiji-linux64.zip">micron.ox.ac.uk (European mirror)</a>
+    </td>
+  </tr>
+
+  <tr>
+    <th><img alt="Linux" src="/media/icons/fiji.png" width="24" height="24"></th>
+    <td>No JRE</td>
+    <td>
+      <a style="text-decoration: underline;" href="https://downloads.imagej.net/fiji/latest/fiji-nojre.zip">imagej.net (USA)</a>,
+      <a style="text-decoration: underline;" href="https://downloads.micron.ox.ac.uk/fiji_update/mirrors/fiji-latest/fiji-nojre.zip">micron.ox.ac.uk (European mirror)</a>
+    </td>
+  </tr>
 </tbody>
 </table>
 </div>


### PR DESCRIPTION
I've recently made a mirror of the Fiji latest release at https://downloads.micron.ox.ac.uk This PR changes the download table to list those mirrors.

The original format wouldn't fit a link to the mirrors in a nice way so I shuffle things around and made a "simple" table. This PR makes it look like this:

![new-table-with-mirrors](https://user-images.githubusercontent.com/916140/196683485-5ee8c2d7-a614-4791-b0a5-760bbf4d7047.png)

I added the underline on the link text (which I guess is not common anymore) because otherwise there's no separation between the two sites (only the comma but that's too small) and it appears to all be a single link instead of two. The underline makes it clear that there's two links there.

For reference, it currently looks like this:

![download-no-mirrors](https://user-images.githubusercontent.com/916140/196683684-17a5411f-3d06-41d4-9612-cf3a7018f79d.png)
