### PR TITLE
Add hint how to set log level when starting ImageJ2 in logging.md

### DIFF
--- a/_pages/develop/logging.md
+++ b/_pages/develop/logging.md
@@ -73,10 +73,16 @@ E.g., in Java code:
 ```java
 System.setProperty("scijava.log.level", "debug");
 ```
-Or via the command line:
+Or via the command line when running a specific class:
 
 ```java
 java -Dscijava.log.level=debug ... myorg.MyMainClass
+```
+
+Or via the command line when starting ImageJ2:
+
+```bash
+ImageJ-[linux64|macosx|win32.exe|win64.exe] -Dscijava.log.level=debug
 ```
 
 You can even customize the logging behavior per package/class hierarchy. For example, to switch on debug level logging for classes in the `org.scijava.plugin` package and subpackages only:


### PR DESCRIPTION
I was missing the hint in the logging documentation how the log level for ImageJ2 can be set on ImageJ2 startup. Since this is in fact possible, it is worth that this is mentioned here in doc so that users can be aware about how this can be done.