### PR TITLE
Update frangi.md

### DIFF
--- a/_pages/plugins/frangi.md
+++ b/_pages/plugins/frangi.md
@@ -9,7 +9,7 @@ categories: [Uncategorized]
 
 _Frangi vesselness_ is an algorithm for detection of tube-like structures (such as in imagery of filamentous structures (blood vessels, neurites, etc.). It applies to both 2D and 3D images and was first described by Frangi et al 1998.[^1] ([PDF](https://link.springer.com/content/pdf/10.1007%252FBFb0056195.pdf)). In many cases, this method is known to be a better alternative to single-scale [Tubeness](/plugins/tubeness) filtering (at least for isotropic images), but it is slower. There are two ImageJ implementations of the algorithm:
 
-- A legacy plugin (In Fiji registered under {% include bc path='Plugins|Process|Frangi Vesselness' %} ([source code](https://github.com/fiji/Feature_Detection)). This is a deprecated implementaton with expected inaccuracies.
+- A legacy plugin (In Fiji registered under {% include bc path='Process|Filters|Frangi Vesselness' %} ([source code](https://github.com/fiji/Feature_Detection)). This is a deprecated implementaton with expected inaccuracies.
 
 - An [ImageJ Op](/libs/imagej-ops/index)  (In Fiji registed under {% include bc path='Plugins|Process|Frangi Vesselness' %}). This version superseeds previous implementations and has been validated/benchmarked againgst other implementations (namely ITK and MATLAB) ([details](https://forum.image.sc/t/frangi-vesselness-filter-feedback/6747)). It requires 3 inputs:
  


### PR DESCRIPTION
Both the legacy and ImageJ Op were listed as being the same menu item. Corrected legacy to location in Process > Filters menu