### PR TITLE
Create myoanalyst.md

### DIFF
--- a/_pages/plugins/myoanalyst.md
+++ b/_pages/plugins/myoanalyst.md
@@ -1,0 +1,25 @@
+---
+mediawiki: MyoAnalyst
+title: MyoAnalyst
+description: MyoAnalyst is a tool to segment and measure size of skeletal muscle fibers.
+section: Contribute:Editing the Wiki
+categories: [Segmentation]
+---gg
+
+## **Introduction**
+
+MyoAnalyst is an ImageJ/Fiji plugin designed for fully automatic analysis of both immunofluorescence (IF)- and H&E-stained skeletal muscle cross sections. 
+
+## **Installation**
+
+The plugin can be downloaded from: https://github.com/ZhangHongbo-Lab/MyoAnalyst/tree/master/jar
+
+Copy the MyoAnalyst_v3.jar to ImageJ's plugins folder. Once ImageJ is restarted the plugin will appear in the Plugin submenu as MyoAnalyst.
+
+## **Usage**
+
+A user guide can be found at: https://github.com/ZhangHongbo-Lab/MyoAnalyst/blob/master/documentation/MyoAnalyst%20User%20Manual.pdf
+
+## **Help**
+
+In case of difficulties using the plugin, create an issue in the following link so we or someone from the community can help you: https://github.com/ZhangHongbo-Lab/MyoAnalyst/issues.


### PR DESCRIPTION
MyoAnalyst is an ImageJ/Fiji plugin designed for fully automatic analysis of both immunofluorescence (IF)- and H&E-stained skeletal muscle cross sections. This plugin features a user-friendly interface, thus will be as an efficient, versatile tool for myofiber quantification, tailored to meet the needs of both researchers and clinicians.